### PR TITLE
Fix mobile number validation

### DIFF
--- a/src/components/ForgotPassword.jsx
+++ b/src/components/ForgotPassword.jsx
@@ -47,7 +47,10 @@ const ForgotPassword = () => {
             style={{ boxShadow: `0 0 0 1.5px ${themeColor}` }}
           />
           <input
-            type="number"
+            type="text"
+            inputMode="numeric"
+            pattern="\\d{10}"
+            maxLength={10}
             value={mobile}
             onChange={(e) => setMobile(e.target.value)}
             placeholder="Registered Mobile Number"

--- a/src/components/Register.jsx
+++ b/src/components/Register.jsx
@@ -90,6 +90,9 @@ const Register = () => {
             <label className="block mb-1 text-sm font-medium text-gray-700">Mobile</label>
             <input
               type="text"
+              inputMode="numeric"
+              pattern="\\d{10}"
+              maxLength={10}
               value={mobile}
               onChange={(e) => setMobile(e.target.value)}
               required

--- a/src/components/Signup.jsx
+++ b/src/components/Signup.jsx
@@ -136,7 +136,10 @@ const Signup = () => {
           />
 
           <input
-            type="number"
+            type="text"
+            inputMode="numeric"
+            pattern="\\d{10}"
+            maxLength={10}
             value={form.mobile_number}
             onChange={handleChange('mobile_number')}
             placeholder="Mobile Number (Login & Contact)"

--- a/src/pages/Admission.jsx
+++ b/src/pages/Admission.jsx
@@ -260,8 +260,24 @@ const Admission = () => {
                 <label><input type="radio" name="gender" value="Male" checked={form.gender === 'Male'} onChange={handleChange('gender')} /> Male</label>
                 <label><input type="radio" name="gender" value="Female" checked={form.gender === 'Female'} onChange={handleChange('gender')} /> Female</label>
               </div>
-              <input placeholder="Mobile (Self)" value={form.mobileSelf} onChange={handleChange('mobileSelf')} className="border p-2" />
-              <input placeholder="Mobile (Parent)" value={form.mobileParent} onChange={handleChange('mobileParent')} className="border p-2" />
+              <input
+                placeholder="Mobile (Self)"
+                value={form.mobileSelf}
+                onChange={handleChange('mobileSelf')}
+                inputMode="numeric"
+                pattern="\\d{10}"
+                maxLength={10}
+                className="border p-2"
+              />
+              <input
+                placeholder="Mobile (Parent)"
+                value={form.mobileParent}
+                onChange={handleChange('mobileParent')}
+                inputMode="numeric"
+                pattern="\\d{10}"
+                maxLength={10}
+                className="border p-2"
+              />
               <input placeholder="Address" value={form.address} onChange={handleChange('address')} className="border p-2" />
 
               <select value={form.education} onChange={handleChange('education')} className="border p-2">

--- a/src/pages/Enquiry.jsx
+++ b/src/pages/Enquiry.jsx
@@ -240,7 +240,15 @@ const AddEnquiry = () => {
               {/* Removed enquiryDate input */}
               <input value={form.firstName} onChange={handleChange('firstName')} placeholder="First Name" className="border p-2" />
               <input value={form.lastName} onChange={handleChange('lastName')} placeholder="Last Name" className="border p-2" />
-              <input value={form.mobileSelf} onChange={handleChange('mobileSelf')} placeholder="Mobile" className="border p-2" />
+              <input
+                value={form.mobileSelf}
+                onChange={handleChange('mobileSelf')}
+                placeholder="Mobile"
+                inputMode="numeric"
+                pattern="\\d{10}"
+                maxLength={10}
+                className="border p-2"
+              />
               <select value={form.course} onChange={handleChange('course')} className="border p-2">
                 <option value="">Select Course</option>
                 {Array.isArray(courses) && courses.map(c => (
@@ -277,8 +285,24 @@ const AddEnquiry = () => {
           <label><input type="radio" name="gender" value="Female" checked={admissionForm.gender === 'Female'} onChange={handleAdmissionChange('gender')} /> Female</label>
         </div>
 
-        <input placeholder="Mobile (Self)" value={admissionForm.mobileSelf} onChange={handleAdmissionChange('mobileSelf')} className="border p-2" />
-        <input placeholder="Mobile (Parent)" value={admissionForm.mobileParent} onChange={handleAdmissionChange('mobileParent')} className="border p-2" />
+        <input
+          placeholder="Mobile (Self)"
+          value={admissionForm.mobileSelf}
+          onChange={handleAdmissionChange('mobileSelf')}
+          inputMode="numeric"
+          pattern="\\d{10}"
+          maxLength={10}
+          className="border p-2"
+        />
+        <input
+          placeholder="Mobile (Parent)"
+          value={admissionForm.mobileParent}
+          onChange={handleAdmissionChange('mobileParent')}
+          inputMode="numeric"
+          pattern="\\d{10}"
+          maxLength={10}
+          className="border p-2"
+        />
         <input placeholder="Address" value={admissionForm.address} onChange={handleAdmissionChange('address')} className="border p-2" />
 
         <select value={admissionForm.education} onChange={handleAdmissionChange('education')} className="border p-2">

--- a/src/pages/Owner.jsx
+++ b/src/pages/Owner.jsx
@@ -218,15 +218,51 @@ const Owner = () => {
             </h2>
             <form onSubmit={handleSubmit} className="space-y-3">
               <input type="text" value={form.organization_title} onChange={handleInputChange('organization_title')} className="w-full p-2 border rounded" placeholder="Title" />
-              <input type="text" value={form.organization_whatsapp_number} onChange={handleInputChange('organization_whatsapp_number')} className="w-full p-2 border rounded" placeholder="WhatsApp Number" />
-              <input type="text" value={form.organization_call_number} onChange={handleInputChange('organization_call_number')} className="w-full p-2 border rounded" placeholder="Call Number"  />
+              <input
+                type="text"
+                value={form.organization_whatsapp_number}
+                onChange={handleInputChange('organization_whatsapp_number')}
+                className="w-full p-2 border rounded"
+                placeholder="WhatsApp Number"
+                inputMode="numeric"
+                pattern="\d{10}"
+                maxLength={10}
+              />
+              <input
+                type="text"
+                value={form.organization_call_number}
+                onChange={handleInputChange('organization_call_number')}
+                className="w-full p-2 border rounded"
+                placeholder="Call Number"
+                inputMode="numeric"
+                pattern="\d{10}"
+                maxLength={10}
+              />
               <input type="text" value={form.organization_whatsapp_message} onChange={handleInputChange('organization_whatsapp_message')} className="w-full p-2 border rounded" placeholder="WhatsApp Message" />
               <input type="text" value={form.login_username} onChange={handleInputChange('login_username')} className="w-full p-2 border rounded" placeholder="Login Username" />
               <input type="password" value={form.login_password} onChange={handleInputChange('login_password')} className="w-full p-2 border rounded" placeholder="Login Password"  />
               <input type="text" value={form.theme_color} onChange={handleInputChange('theme_color')} className="w-full p-2 border rounded" placeholder="Theme Color" />
               <input type="text" value={form.domains} onChange={handleInputChange('domains')} className="w-full p-2 border rounded" placeholder="Domains" />
-              <input type="text" value={form.org_whatsapp_number} onChange={handleInputChange('org_whatsapp_number')} className="w-full p-2 border rounded" placeholder="Org WhatsApp Number" />
-              <input type="text" value={form.org_call_number} onChange={handleInputChange('org_call_number')} className="w-full p-2 border rounded" placeholder="Org Call Number" />
+              <input
+                type="text"
+                value={form.org_whatsapp_number}
+                onChange={handleInputChange('org_whatsapp_number')}
+                className="w-full p-2 border rounded"
+                placeholder="Org WhatsApp Number"
+                inputMode="numeric"
+                pattern="\d{10}"
+                maxLength={10}
+              />
+              <input
+                type="text"
+                value={form.org_call_number}
+                onChange={handleInputChange('org_call_number')}
+                className="w-full p-2 border rounded"
+                placeholder="Org Call Number"
+                inputMode="numeric"
+                pattern="\d{10}"
+                maxLength={10}
+              />
 
               <input type="file" accept="image/*" ref={fileInputRef} onChange={handleFileChange} className="w-full p-2 border rounded" />
               {previewLogo && <img src={previewLogo} alt="Preview" className="w-24 h-24 object-cover rounded mt-2" />}

--- a/src/pages/User.jsx
+++ b/src/pages/User.jsx
@@ -161,7 +161,17 @@ const User = () => {
             <form onSubmit={handleSubmit} className="space-y-3">
               <input type="text" value={form.name} onChange={handleInputChange('name')} className="w-full p-2 border rounded" placeholder="Name" required />
               <input type="text" value={form.password} onChange={handleInputChange('password')} className="w-full p-2 border rounded" placeholder="Password" required />
-              <input type="text" value={form.mobile} onChange={handleInputChange('mobile')} className="w-full p-2 border rounded" placeholder="Mobile No." required />
+              <input
+                type="text"
+                inputMode="numeric"
+                pattern="\\d{10}"
+                maxLength={10}
+                value={form.mobile}
+                onChange={handleInputChange('mobile')}
+                className="w-full p-2 border rounded"
+                placeholder="Mobile No."
+                required
+              />
               <input type="text" value={form.type} onChange={handleInputChange('type')} className="w-full p-2 border rounded" placeholder="Type" required />
               <div className="flex justify-end gap-2">
                 <button type="button" onClick={() => setShowModal(false)} className="bg-gray-500 text-white px-4 py-2 rounded">Cancel</button>


### PR DESCRIPTION
## Summary
- enforce 10-digit numeric format for all mobile number inputs
- add numeric validation for organization phone numbers in owner page

## Testing
- `npm test` *(fails: Missing script and network access)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6852421cafbc8322a0db12e34c245807