### PR TITLE
Fix BASE_URL usage in axios calls

### DIFF
--- a/src/components/ImageUploader.jsx
+++ b/src/components/ImageUploader.jsx
@@ -31,7 +31,7 @@ const ImageUploader = () => {
     formData.append('image', file);
 
     try {
-      const res = await axios.post('${BASE_URL}/api/upload', formData, {
+      const res = await axios.post(`${BASE_URL}/api/upload`, formData, {
         headers: {
           'Authorization': 'Bearer ' + localStorage.getItem('token'),
           'Content-Type': 'multipart/form-data'

--- a/src/components/Register.jsx
+++ b/src/components/Register.jsx
@@ -32,7 +32,7 @@ const Register = () => {
     const organization_id = localStorage.getItem("organization_id");
 
     try {
-      const res = await axios.post("${BASE_URL}/api/auth/register", {
+      const res = await axios.post(`${BASE_URL}/api/auth/register`, {
         name: name.trim(),
         password: password.trim(),
         mobile: mobile.trim(),

--- a/src/pages/Owner.jsx
+++ b/src/pages/Owner.jsx
@@ -32,7 +32,7 @@ const Owner = () => {
 
   const fetchOrganizations = async () => {
     try {
-      const res = await axios.get('${BASE_URL}/api/organize/GetOrganizList');
+      const res = await axios.get(`${BASE_URL}/api/organize/GetOrganizList`);
       if (res.data?.success) {
         setOrganizations(res.data.result);
       } else {
@@ -77,7 +77,7 @@ const Owner = () => {
       } else {
         // Create
         const res = await axios.post(
-          '${BASE_URL}/api/organize/add',
+          `${BASE_URL}/api/organize/add`,
           formData,
           {
             headers: { 'Content-Type': 'multipart/form-data' }

--- a/src/pages/User.jsx
+++ b/src/pages/User.jsx
@@ -64,7 +64,7 @@ const User = () => {
         await axios.put(`${BASE_URL}/api/auth/${editingId}`, dataToSend);
         toast.success('User updated');
       } else {
-        const res = await axios.post('${BASE_URL}/api/auth/register', dataToSend);
+        const res = await axios.post(`${BASE_URL}/api/auth/register`, dataToSend);
         if (res.data === 'exist') toast.error('User already exists');
         else if (res.data === 'notexist') toast.success('User added');
         else toast.error('Unexpected error');


### PR DESCRIPTION
## Summary
- correct axios URL generation by using template literals instead of plain strings

## Testing
- `npm run build` *(fails: 403 Forbidden when fetching from npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_6852dd607dd08322b8b952a855ec0ec8