### PR TITLE
Improve config and add README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,25 @@
+# SocialFront
+
+React dashboard client for the Instify platform.
+
+## Development
+
+1. Install dependencies
+   ```bash
+   npm install
+   ```
+2. Create a `.env` file and set `VITE_API_URL` if you want to override the default API URL.
+3. Start the dev server
+   ```bash
+   npm run dev
+   ```
+
+## Build
+
+To create a production build run:
+```bash
+npm run build
+```
+
+This project uses Vite, React, and Tailwind CSS.
+

--- a/src/config.js
+++ b/src/config.js
@@ -1,11 +1,7 @@
-let BASE_URL = '';
-
-if (window?.location?.hostname === 'localhost') {
-  // Local development
-  BASE_URL = 'http://localhost:5000';
-} else {
-  // Production or fallback
-  BASE_URL = 'https://socialbackend-iucy.onrender.com';
-}
+const BASE_URL =
+  import.meta.env.VITE_API_URL ||
+  (window.location.hostname === 'localhost'
+    ? 'http://localhost:5000'
+    : 'https://socialbackend-iucy.onrender.com');
 
 export default BASE_URL;


### PR DESCRIPTION
## Summary
- use env variable for API URL in `src/config.js`
- add README with basic development instructions

## Testing
- `npm run build` *(fails: 403 Forbidden - registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_685d6717cf7c83228af507f53dde944e