### PR TITLE
Switch tables to card view

### DIFF
--- a/src/Reports/allAdmission.jsx
+++ b/src/Reports/allAdmission.jsx
@@ -30,6 +30,7 @@ const AllAdmission = () => {
   const [batches, setBatches] = useState([]);
   const themeColor = localStorage.getItem('theme_color') || '#10B981';
   const [paymentModes, setPaymentModes] = useState([]);
+  const [actionModal, setActionModal] = useState(null);
 
   const institute_uuid = localStorage.getItem("institute_uuid");
 
@@ -213,28 +214,20 @@ const AllAdmission = () => {
         </div>
       </div>
 
-      {/* Table */}
-      <table className="w-full border">
-        <thead className="bg-gray-100">
-          <tr>
-            <th className="p-2 border">Name</th>
-            <th className="p-2 border">Mobile</th>
-            <th className="p-2 border">Action</th>
-          </tr>
-        </thead>
-        <tbody>
-          {filteredAdmissions.map((a, i) => (
-            <tr key={i} className="text-center">
-              <td className="border p-2">{a.firstName} {a.lastName}</td>
-              <td className="border p-2">{a.mobileSelf}</td>
-              <td className="border p-2 space-x-2">
-                <button onClick={() => handleEdit(a)} className="bg-yellow-500 text-white px-2 py-1 rounded">Edit</button>
-                <button onClick={() => handleDelete(a._id)} className="bg-red-500 text-white px-2 py-1 rounded">Delete</button>
-              </td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
+      {/* Card Grid */}
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
+        {filteredAdmissions.map((a) => (
+          <div
+            key={a._id}
+            className="bg-white p-4 rounded shadow cursor-pointer hover:ring hover:ring-blue-400"
+            onClick={() => setActionModal(a)}
+          >
+            <div className="font-semibold text-lg">{a.firstName} {a.lastName}</div>
+            <div className="text-gray-600 text-sm">📞 {a.mobileSelf}</div>
+            <div className="text-gray-500 text-xs">{a.course || 'No course selected'}</div>
+          </div>
+        ))}
+      </div>
 
       {/* Modal */}
       {showModal && (
@@ -342,6 +335,43 @@ const AllAdmission = () => {
                 <button type="submit" className="bg-blue-600 text-white px-4 py-2 rounded">{editingId ? 'Update' : 'Submit'}</button>
               </div>
             </form>
+          </div>
+        </div>
+      )}
+
+      {/* Action Modal */}
+      {actionModal && (
+        <div className="fixed inset-0 bg-black bg-opacity-40 flex items-center justify-center z-50">
+          <div className="bg-white p-6 rounded max-w-sm w-full">
+            <h2 className="text-lg font-bold mb-4">
+              {actionModal.firstName} {actionModal.lastName}
+            </h2>
+            <div className="flex flex-wrap gap-2">
+              <button
+                onClick={() => {
+                  handleEdit(actionModal);
+                  setActionModal(null);
+                }}
+                className="bg-yellow-500 text-white px-4 py-2 rounded text-sm"
+              >
+                Edit
+              </button>
+              <button
+                onClick={() => {
+                  handleDelete(actionModal._id);
+                  setActionModal(null);
+                }}
+                className="bg-red-500 text-white px-4 py-2 rounded text-sm"
+              >
+                Delete
+              </button>
+              <button
+                onClick={() => setActionModal(null)}
+                className="bg-gray-400 text-white px-4 py-2 rounded text-sm ml-auto"
+              >
+                Close
+              </button>
+            </div>
           </div>
         </div>
       )}

--- a/src/Reports/allEnquiry.jsx
+++ b/src/Reports/allEnquiry.jsx
@@ -30,6 +30,7 @@ const AllEnquiry = () => {
   const [exams, setExams] = useState([]);
   const [batches, setBatches] = useState([]);
   const [paymentModes, setPaymentModes] = useState([]);
+  const [actionModal, setActionModal] = useState(null);
   const [search, setSearch] = useState('');
   const institute_uuid = localStorage.getItem('institute_uuid');
   const themeColor = localStorage.getItem('theme_color') || '#10B981';
@@ -215,31 +216,22 @@ const AllEnquiry = () => {
         <input value={search} onChange={e => setSearch(e.target.value)} placeholder="Search" className="border p-2" />
       </div>
 
-      <table className="w-full border">
-        <thead>
-          <tr>
-            <th className="border p-2">Name</th>
-            <th className="border p-2">Mobile</th>
-            <th className="border p-2">Actions</th>
-          </tr>
-        </thead>
-        <tbody>
-          {filtered.map((e, i) => (
-            <tr key={i} className="text-center">
-              <td className="border p-2">{e.firstName} {e.lastName}</td>
-              <td className="border p-2">{e.mobileSelf}</td>
-              <td className="border p-2 space-x-2">
-                <button onClick={() => handleEdit(e)} className="bg-yellow-500 text-white px-2 py-1 rounded">Edit</button>
-                <button onClick={() => handleDelete(e._id)} className="bg-red-500 text-white px-2 py-1 rounded">Delete</button>
-                <button onClick={() => handleConvert(e)} className="bg-green-600 text-white px-2 py-1 rounded">Convert</button>
-              </td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
+        {filtered.map((e) => (
+          <div
+            key={e._id}
+            className="bg-white p-4 rounded shadow cursor-pointer hover:ring hover:ring-blue-400"
+            onClick={() => setActionModal(e)}
+          >
+            <div className="font-semibold text-lg">{e.firstName} {e.lastName}</div>
+            <div className="text-gray-600 text-sm">📞 {e.mobileSelf}</div>
+            <div className="text-gray-500 text-xs">{e.course || 'No course selected'}</div>
+          </div>
+        ))}
+      </div>
 
       {/* Admission Convert Modal */}
-      {showAdmission && (
+  {showAdmission && (
   <div className="fixed inset-0 bg-black bg-opacity-40 flex items-center justify-center z-50">
     <div className="bg-white p-6 rounded shadow max-w-xl w-full max-h-[90vh] overflow-y-auto">
       <h2 className="text-2xl font-bold mb-4 text-green-700">Convert to Admission</h2>
@@ -342,6 +334,52 @@ const AllEnquiry = () => {
     </div>
   </div>
 )}
+
+      {/* Action Modal */}
+      {actionModal && (
+        <div className="fixed inset-0 bg-black bg-opacity-40 flex items-center justify-center z-50">
+          <div className="bg-white p-6 rounded max-w-sm w-full">
+            <h2 className="text-lg font-bold mb-4">
+              {actionModal.firstName} {actionModal.lastName}
+            </h2>
+            <div className="flex flex-wrap gap-2">
+              <button
+                onClick={() => {
+                  handleEdit(actionModal);
+                  setActionModal(null);
+                }}
+                className="bg-yellow-500 text-white px-4 py-2 rounded text-sm"
+              >
+                Edit
+              </button>
+              <button
+                onClick={() => {
+                  handleDelete(actionModal._id);
+                  setActionModal(null);
+                }}
+                className="bg-red-500 text-white px-4 py-2 rounded text-sm"
+              >
+                Delete
+              </button>
+              <button
+                onClick={() => {
+                  handleConvert(actionModal);
+                  setActionModal(null);
+                }}
+                className="bg-green-600 text-white px-4 py-2 rounded text-sm"
+              >
+                Convert
+              </button>
+              <button
+                onClick={() => setActionModal(null)}
+                className="bg-gray-400 text-white px-4 py-2 rounded text-sm ml-auto"
+              >
+                Close
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
 
     </div>
   );

--- a/src/pages/Admission.jsx
+++ b/src/pages/Admission.jsx
@@ -24,6 +24,7 @@ const Admission = () => {
   const [startDate, setStartDate] = useState('');
   const [endDate, setEndDate] = useState('');
   const [showModal, setShowModal] = useState(false);
+  const [actionModal, setActionModal] = useState(null);
   const [courses, setCourses] = useState([]);
   const [educations, setEducations] = useState([]);
   const [exams, setExams] = useState([]);
@@ -214,28 +215,24 @@ const Admission = () => {
         </div>
       </div>
 
-      {/* Table */}
-      <table className="w-full border">
-        <thead className="bg-gray-100">
-          <tr>
-            <th className="p-2 border">Name</th>
-            <th className="p-2 border">Mobile</th>
-            <th className="p-2 border">Action</th>
-          </tr>
-        </thead>
-        <tbody>
-          {filteredAdmissions.map((a, i) => (
-            <tr key={i} className="text-center">
-              <td className="border p-2">{a.firstName} {a.lastName}</td>
-              <td className="border p-2">{a.mobileSelf}</td>
-              <td className="border p-2 space-x-2">
-                <button onClick={() => handleEdit(a)} className="bg-yellow-500 text-white px-2 py-1 rounded">Edit</button>
-                <button onClick={() => handleDelete(a._id)} className="bg-red-500 text-white px-2 py-1 rounded">Delete</button>
-              </td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
+      {/* Card View */}
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
+        {filteredAdmissions.map((a) => (
+          <div
+            key={a._id}
+            className="bg-white p-4 rounded shadow cursor-pointer hover:ring hover:ring-blue-400"
+            onClick={() => setActionModal(a)}
+          >
+            <div className="font-semibold text-lg">
+              {a.firstName} {a.lastName}
+            </div>
+            <div className="text-gray-600 text-sm">📞 {a.mobileSelf}</div>
+            <div className="text-gray-500 text-xs">
+              {a.course || 'No course selected'}
+            </div>
+          </div>
+        ))}
+      </div>
 
       {/* Modal */}
       {showModal && (
@@ -343,6 +340,43 @@ const Admission = () => {
                 <button type="submit" className="bg-blue-600 text-white px-4 py-2 rounded">{editingId ? 'Update' : 'Submit'}</button>
               </div>
             </form>
+          </div>
+        </div>
+      )}
+
+      {/* Action Modal */}
+      {actionModal && (
+        <div className="fixed inset-0 bg-black bg-opacity-40 flex items-center justify-center z-50">
+          <div className="bg-white p-6 rounded max-w-sm w-full">
+            <h2 className="text-lg font-bold mb-4">
+              {actionModal.firstName} {actionModal.lastName}
+            </h2>
+            <div className="flex flex-wrap gap-2">
+              <button
+                onClick={() => {
+                  handleEdit(actionModal);
+                  setActionModal(null);
+                }}
+                className="bg-yellow-500 text-white px-4 py-2 rounded text-sm"
+              >
+                Edit
+              </button>
+              <button
+                onClick={() => {
+                  handleDelete(actionModal._id);
+                  setActionModal(null);
+                }}
+                className="bg-red-500 text-white px-4 py-2 rounded text-sm"
+              >
+                Delete
+              </button>
+              <button
+                onClick={() => setActionModal(null)}
+                className="bg-gray-400 text-white px-4 py-2 rounded text-sm ml-auto"
+              >
+                Close
+              </button>
+            </div>
           </div>
         </div>
       )}

--- a/src/pages/Enquiry.jsx
+++ b/src/pages/Enquiry.jsx
@@ -18,6 +18,7 @@ const Enquiry = () => {
   const [followUpDate, setFollowUpDate] = useState('');
   const [followUpRemarks, setFollowUpRemarks] = useState('');
   const [search, setSearch] = useState('');
+  const [actionModal, setActionModal] = useState(null);
   const institute_uuid = localStorage.getItem('institute_uuid');
 
   const fetchEnquiries = async () => {
@@ -146,16 +147,11 @@ const Enquiry = () => {
           <div
             key={e._id}
             className="bg-white p-4 rounded shadow cursor-pointer hover:ring hover:ring-blue-400"
+            onClick={() => setActionModal(e)}
           >
             <div className="font-semibold text-lg">{e.firstName} {e.lastName}</div>
             <div className="text-gray-600 text-sm">📞 {e.mobileSelf}</div>
             <div className="text-gray-500 text-xs">{e.course || 'No course selected'}</div>
-            <div className="flex flex-wrap gap-2 mt-2">
-              <button onClick={() => openEditModal(e)} className="bg-yellow-500 text-white px-3 py-1 rounded text-xs">Edit</button>
-              <button onClick={() => handleDelete(e._id)} className="bg-red-500 text-white px-3 py-1 rounded text-xs">Delete</button>
-              <button onClick={() => toast('Convert to Admission logic pending')} className="bg-green-600 text-white px-3 py-1 rounded text-xs">Convert</button>
-              <button onClick={() => openFollowUpModal(e)} className="bg-blue-600 text-white px-3 py-1 rounded text-xs">Follow-Up</button>
-            </div>
           </div>
         ))}
       </div>
@@ -252,6 +248,61 @@ const Enquiry = () => {
                 </button>
               </div>
             </form>
+          </div>
+        </div>
+      )}
+
+      {/* Action Modal */}
+      {actionModal && (
+        <div className="fixed inset-0 bg-black bg-opacity-40 flex items-center justify-center z-50">
+          <div className="bg-white p-6 rounded max-w-sm w-full">
+            <h2 className="text-lg font-bold mb-4">
+              {actionModal.firstName} {actionModal.lastName}
+            </h2>
+            <div className="flex flex-wrap gap-2">
+              <button
+                onClick={() => {
+                  openEditModal(actionModal);
+                  setActionModal(null);
+                }}
+                className="bg-yellow-500 text-white px-4 py-2 rounded text-sm"
+              >
+                Edit
+              </button>
+              <button
+                onClick={() => {
+                  handleDelete(actionModal._id);
+                  setActionModal(null);
+                }}
+                className="bg-red-500 text-white px-4 py-2 rounded text-sm"
+              >
+                Delete
+              </button>
+              <button
+                onClick={() => {
+                  toast('Convert to Admission logic pending');
+                  setActionModal(null);
+                }}
+                className="bg-green-600 text-white px-4 py-2 rounded text-sm"
+              >
+                Convert
+              </button>
+              <button
+                onClick={() => {
+                  openFollowUpModal(actionModal);
+                  setActionModal(null);
+                }}
+                className="bg-blue-600 text-white px-4 py-2 rounded text-sm"
+              >
+                Follow-Up
+              </button>
+              <button
+                onClick={() => setActionModal(null)}
+                className="bg-gray-400 text-white px-4 py-2 rounded text-sm ml-auto"
+              >
+                Close
+              </button>
+            </div>
           </div>
         </div>
       )}

--- a/src/pages/Followup.jsx
+++ b/src/pages/Followup.jsx
@@ -31,6 +31,7 @@ const Followup = () => {
   const [batches, setBatches] = useState([]);
   const [paymentModes, setPaymentModes] = useState([]);
   const [search, setSearch] = useState('');
+  const [actionModal, setActionModal] = useState(null);
   const institute_uuid = localStorage.getItem('institute_uuid');
   const themeColor = localStorage.getItem('theme_color') || '#10B981';
 
@@ -215,28 +216,23 @@ const Followup = () => {
         <input value={search} onChange={e => setSearch(e.target.value)} placeholder="Search" className="border p-2" />
       </div>
 
-      <table className="w-full border">
-        <thead>
-          <tr>
-            <th className="border p-2">Name</th>
-            <th className="border p-2">Mobile</th>
-            <th className="border p-2">Actions</th>
-          </tr>
-        </thead>
-        <tbody>
-          {filtered.map((e, i) => (
-            <tr key={i} className="text-center">
-              <td className="border p-2">{e.firstName} {e.lastName}</td>
-              <td className="border p-2">{e.mobileSelf}</td>
-              <td className="border p-2 space-x-2">
-                <button onClick={() => handleEdit(e)} className="bg-yellow-500 text-white px-2 py-1 rounded">Edit</button>
-                <button onClick={() => handleDelete(e._id)} className="bg-red-500 text-white px-2 py-1 rounded">Delete</button>
-                <button onClick={() => handleConvert(e)} className="bg-green-600 text-white px-2 py-1 rounded">Convert</button>
-              </td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
+        {filtered.map((e) => (
+          <div
+            key={e._id}
+            className="bg-white p-4 rounded shadow cursor-pointer hover:ring hover:ring-blue-400"
+            onClick={() => setActionModal(e)}
+          >
+            <div className="font-semibold text-lg">
+              {e.firstName} {e.lastName}
+            </div>
+            <div className="text-gray-600 text-sm">📞 {e.mobileSelf}</div>
+            <div className="text-gray-500 text-xs">
+              {e.course || 'No course selected'}
+            </div>
+          </div>
+        ))}
+      </div>
 
       {/* Admission Convert Modal */}
       {showAdmission && (
@@ -341,7 +337,53 @@ const Followup = () => {
       </form>
     </div>
   </div>
-)}
+  )}
+
+      {/* Action Modal */}
+      {actionModal && (
+        <div className="fixed inset-0 bg-black bg-opacity-40 flex items-center justify-center z-50">
+          <div className="bg-white p-6 rounded max-w-sm w-full">
+            <h2 className="text-lg font-bold mb-4">
+              {actionModal.firstName} {actionModal.lastName}
+            </h2>
+            <div className="flex flex-wrap gap-2">
+              <button
+                onClick={() => {
+                  handleEdit(actionModal);
+                  setActionModal(null);
+                }}
+                className="bg-yellow-500 text-white px-4 py-2 rounded text-sm"
+              >
+                Edit
+              </button>
+              <button
+                onClick={() => {
+                  handleDelete(actionModal._id);
+                  setActionModal(null);
+                }}
+                className="bg-red-500 text-white px-4 py-2 rounded text-sm"
+              >
+                Delete
+              </button>
+              <button
+                onClick={() => {
+                  handleConvert(actionModal);
+                  setActionModal(null);
+                }}
+                className="bg-green-600 text-white px-4 py-2 rounded text-sm"
+              >
+                Convert
+              </button>
+              <button
+                onClick={() => setActionModal(null)}
+                className="bg-gray-400 text-white px-4 py-2 rounded text-sm ml-auto"
+              >
+                Close
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
 
     </div>
   );


### PR DESCRIPTION
## Summary
- replace the admissions table with card grid layout
- switch followup list to cards
- show action buttons from a modal when a card is clicked

## Testing
- `npm run build` *(fails: 403 Forbidden - registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_685ed735867c8322af73e89544b668da