### PR TITLE
Add call & WhatsApp links

### DIFF
--- a/src/Reports/allAdmission.jsx
+++ b/src/Reports/allAdmission.jsx
@@ -223,7 +223,22 @@ const AllAdmission = () => {
             onClick={() => setActionModal(a)}
           >
             <div className="font-semibold text-lg">{a.firstName} {a.lastName}</div>
-            <div className="text-gray-600 text-sm">📞 {a.mobileSelf}</div>
+            <div className="flex items-center gap-2 text-gray-600 text-sm">
+              <a
+                href={`tel:${a.mobileSelf}`}
+                onClick={ev => ev.stopPropagation()}
+                className="hover:underline"
+              >
+                📞 {a.mobileSelf}
+              </a>
+              <a
+                href={`https://wa.me/${a.mobileSelf}`}
+                onClick={ev => ev.stopPropagation()}
+                className="bg-green-500 text-white px-2 py-1 rounded text-xs"
+              >
+                WhatsApp
+              </a>
+            </div>
             <div className="text-gray-500 text-xs">{a.course || 'No course selected'}</div>
           </div>
         ))}

--- a/src/Reports/allEnquiry.jsx
+++ b/src/Reports/allEnquiry.jsx
@@ -224,7 +224,22 @@ const AllEnquiry = () => {
             onClick={() => setActionModal(e)}
           >
             <div className="font-semibold text-lg">{e.firstName} {e.lastName}</div>
-            <div className="text-gray-600 text-sm">📞 {e.mobileSelf}</div>
+            <div className="flex items-center gap-2 text-gray-600 text-sm">
+              <a
+                href={`tel:${e.mobileSelf}`}
+                onClick={ev => ev.stopPropagation()}
+                className="hover:underline"
+              >
+                📞 {e.mobileSelf}
+              </a>
+              <a
+                href={`https://wa.me/${e.mobileSelf}`}
+                onClick={ev => ev.stopPropagation()}
+                className="bg-green-500 text-white px-2 py-1 rounded text-xs"
+              >
+                WhatsApp
+              </a>
+            </div>
             <div className="text-gray-500 text-xs">{e.course || 'No course selected'}</div>
           </div>
         ))}

--- a/src/pages/Followup.jsx
+++ b/src/pages/Followup.jsx
@@ -226,7 +226,22 @@ const Followup = () => {
             <div className="font-semibold text-lg">
               {e.firstName} {e.lastName}
             </div>
-            <div className="text-gray-600 text-sm">📞 {e.mobileSelf}</div>
+            <div className="flex items-center gap-2 text-gray-600 text-sm">
+              <a
+                href={`tel:${e.mobileSelf}`}
+                onClick={ev => ev.stopPropagation()}
+                className="hover:underline"
+              >
+                📞 {e.mobileSelf}
+              </a>
+              <a
+                href={`https://wa.me/${e.mobileSelf}`}
+                onClick={ev => ev.stopPropagation()}
+                className="bg-green-500 text-white px-2 py-1 rounded text-xs"
+              >
+                WhatsApp
+              </a>
+            </div>
             <div className="text-gray-500 text-xs">
               {e.course || 'No course selected'}
             </div>


### PR DESCRIPTION
## Summary
- make contact numbers clickable for direct calls
- add WhatsApp links beside phone numbers in Followup, AllAdmission and AllEnquiry card views

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685edf9da1108322a722df38f1c3ac14