### PR TITLE
Implement persisted login redirect logic

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -20,6 +20,7 @@ import ResetPassword from './components/ResetPassword';
 import InstituteProfile from './pages/instituteProfile';
 import Owner from './pages/Owner';
 import PrivateRoute from './components/PrivateRoute'; // ✅ Assuming this is implemented
+import PublicRoute from './components/PublicRoute';
 import CoursesCategory from './pages/CoursesCategory';
 import AllEnquiry from './Reports/allEnquiry';
 import AllAdmission from './Reports/allAdmission';
@@ -31,9 +32,32 @@ export default function App() {
   return (
     <Routes>
       {/* 🌐 Public Routes */}
-      <Route path="/" element={<Login />} />
-      {<Route path="/register" element={<Register />} />}
-      <Route path="/signup" element={<Signup />} />
+      <Route
+        path="/"
+        element={
+          <PublicRoute>
+            <Login />
+          </PublicRoute>
+        }
+      />
+      {
+        <Route
+          path="/register"
+          element={
+            <PublicRoute>
+              <Register />
+            </PublicRoute>
+          }
+        />
+      }
+      <Route
+        path="/signup"
+        element={
+          <PublicRoute>
+            <Signup />
+          </PublicRoute>
+        }
+      />
       <Route path="/upload" element={<ImageUploader />} />
       <Route path="/forgot-password" element={<ForgotPassword />} />
       <Route path="/reset-password/:id" element={<ResetPassword />} />

--- a/src/components/PublicRoute.jsx
+++ b/src/components/PublicRoute.jsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { Navigate } from 'react-router-dom';
+import { useApp } from '../Context/AppContext';
+
+const PublicRoute = ({ children }) => {
+  const { user, institute, loading } = useApp();
+
+  if (loading) {
+    return (
+      <div className="flex justify-center items-center h-screen text-gray-500">
+        Loading...
+      </div>
+    );
+  }
+
+  if (user && institute?.institute_uuid) {
+    return <Navigate to="/dashboard" replace />;
+  }
+
+  return children;
+};
+
+export default PublicRoute;


### PR DESCRIPTION
## Summary
- add `PublicRoute` to redirect authenticated users away from login/register pages
- wrap login, register, and signup routes with `PublicRoute`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685fe56e40148322b8ffab3ac4857e35