### PR TITLE
Refactor admissions page

### DIFF
--- a/src/components/admission/AdmissionCard.jsx
+++ b/src/components/admission/AdmissionCard.jsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+/** Card showing a brief overview of an admission record. */
+const AdmissionCard = ({ data, onClick }) => (
+  <div
+    className="bg-white p-4 rounded shadow cursor-pointer hover:ring hover:ring-blue-400"
+    onClick={onClick}
+  >
+    <div className="font-semibold text-lg">
+      {data.firstName} {data.lastName}
+    </div>
+    <div className="text-gray-600 text-sm">📞 {data.mobileSelf}</div>
+    <div className="text-gray-500 text-xs">{data.course || 'No course selected'}</div>
+  </div>
+);
+
+export default AdmissionCard;

--- a/src/components/admission/AdmissionForm.jsx
+++ b/src/components/admission/AdmissionForm.jsx
@@ -35,7 +35,7 @@ const AdmissionForm = ({
   );
 
   return (
-    <Modal title={title} actions={actions}>
+    <Modal title={title} actions={actions} onClose={onCancel}>
       <form onSubmit={onSubmit} className="flex flex-col gap-3">
         <input
           placeholder="First Name"

--- a/src/components/admission/AdmissionForm.jsx
+++ b/src/components/admission/AdmissionForm.jsx
@@ -1,0 +1,198 @@
+import React from 'react';
+import Modal from '../common/Modal';
+
+/**
+ * Form used for creating or updating an admission.
+ * Receives form state and lists via props and delegates submission back to the parent.
+ */
+const AdmissionForm = ({
+  form,
+  editingId,
+  educations,
+  courses,
+  exams,
+  batches,
+  paymentModes,
+  onChange,
+  onSubmit,
+  onCancel,
+}) => {
+  const title = editingId ? 'Edit Admission' : 'Add New Admission';
+
+  const actions = (
+    <>
+      <button
+        type="button"
+        onClick={onCancel}
+        className="bg-gray-500 text-white px-4 py-2 rounded"
+      >
+        Cancel
+      </button>
+      <button type="submit" className="bg-blue-600 text-white px-4 py-2 rounded">
+        {editingId ? 'Update' : 'Submit'}
+      </button>
+    </>
+  );
+
+  return (
+    <Modal title={title} actions={actions}>
+      <form onSubmit={onSubmit} className="flex flex-col gap-3">
+        <input
+          placeholder="First Name"
+          value={form.firstName}
+          onChange={onChange('firstName')}
+          className="border p-2"
+          required
+        />
+        <input
+          placeholder="Middle Name"
+          value={form.middleName}
+          onChange={onChange('middleName')}
+          className="border p-2"
+        />
+        <input
+          placeholder="Last Name"
+          value={form.lastName}
+          onChange={onChange('lastName')}
+          className="border p-2"
+        />
+        <div className="flex items-center gap-4">
+          <input
+            type="date"
+            value={form.dob?.substring(0, 10)}
+            onChange={onChange('dob')}
+            className="border p-2 flex-1"
+            required
+          />
+          <label className="w-32 text-sm font-medium">Date of Birth</label>
+        </div>
+        <div className="flex gap-4">
+          <label>
+            <input
+              type="radio"
+              name="gender"
+              value="Male"
+              checked={form.gender === 'Male'}
+              onChange={onChange('gender')}
+            />
+            Male
+          </label>
+          <label>
+            <input
+              type="radio"
+              name="gender"
+              value="Female"
+              checked={form.gender === 'Female'}
+              onChange={onChange('gender')}
+            />
+            Female
+          </label>
+        </div>
+        <input
+          placeholder="Mobile (Self)"
+          value={form.mobileSelf}
+          onChange={onChange('mobileSelf')}
+          inputMode="numeric"
+          pattern="[0-9]{10}"
+          maxLength={10}
+          className="border p-2"
+        />
+        <input
+          placeholder="Mobile (Parent)"
+          value={form.mobileParent}
+          onChange={onChange('mobileParent')}
+          inputMode="numeric"
+          pattern="[0-9]{10}"
+          maxLength={10}
+          className="border p-2"
+        />
+        <input
+          placeholder="Address"
+          value={form.address}
+          onChange={onChange('address')}
+          className="border p-2"
+        />
+        <select value={form.education} onChange={onChange('education')} className="border p-2">
+          <option value="">-- Select Education --</option>
+          {educations.map((e) => (
+            <option key={e._id} value={e.education}>
+              {e.education}
+            </option>
+          ))}
+        </select>
+        <select
+          value={form.course}
+          onChange={(e) => {
+            const selected = courses.find((c) => c.name === e.target.value);
+            const courseFee = Number(selected?.courseFees || 0);
+            const discount = Number(form.discount || 0);
+            const feePaid = Number(form.feePaid || 0);
+            const total = courseFee - discount;
+            const balance = total - feePaid;
+            onChange('course')({ target: { value: e.target.value } });
+            onChange('fees')({ target: { value: courseFee } });
+            onChange('total')({ target: { value: total } });
+            onChange('balance')({ target: { value: balance } });
+          }}
+          className="border p-2"
+        >
+          <option value="">-- Select Course --</option>
+          {courses.map((c) => (
+            <option key={c._id} value={c.name}>
+              {c.name}
+            </option>
+          ))}
+        </select>
+        <select value={form.batchTime} onChange={onChange('batchTime')} className="border p-2">
+          <option value="">-- Select Batch --</option>
+          {batches.map((b) => (
+            <option key={b._id} value={b.time || b.batchTime || b.name || ''}>
+              {b.time || b.batchTime || b.name || 'Unnamed Batch'}
+            </option>
+          ))}
+        </select>
+        <select value={form.examEvent} onChange={onChange('examEvent')} className="border p-2">
+          <option value="">-- Select Exam --</option>
+          {exams.map((e) => (
+            <option key={e._id} value={e.exam}>
+              {e.exam}
+            </option>
+          ))}
+        </select>
+        <input
+          placeholder="Installment"
+          value={form.installment}
+          onChange={onChange('installment')}
+          className="border p-2"
+        />
+        <input placeholder="Fees" value={form.fees} type="number" className="border p-2" readOnly />
+        <input
+          placeholder="Discount"
+          value={form.discount}
+          type="number"
+          onChange={onChange('discount')}
+          className="border p-2"
+        />
+        <input placeholder="Total" value={form.total} type="number" className="border p-2" readOnly />
+        <input
+          placeholder="Fee Paid"
+          value={form.feePaid}
+          type="number"
+          onChange={onChange('feePaid')}
+          className="border p-2"
+        />
+        <select value={form.paidBy} onChange={onChange('paidBy')} className="border p-2">
+          <option value="">-- Select Payment Mode --</option>
+          {paymentModes.map((p) => (
+            <option key={p._id} value={p.mode}>
+              {p.mode}
+            </option>
+          ))}
+        </select>
+        <input placeholder="Balance" value={form.balance} type="number" className="border p-2" readOnly />
+      </form>
+    </Modal>
+  );
+};
+
+export default AdmissionForm;

--- a/src/components/common/Modal.jsx
+++ b/src/components/common/Modal.jsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+/**
+ * Generic modal container. Renders children in a centered box with a dark overlay.
+ * Accepts a title, optional actions and an onClose handler.
+ */
+const Modal = ({ title, onClose, actions, children }) => (
+  <div className="fixed inset-0 bg-black bg-opacity-40 flex items-center justify-center z-50">
+    <div className="bg-white p-6 rounded shadow max-w-xl w-full max-h-[90vh] overflow-y-auto">
+      {title && <h2 className="text-xl font-semibold mb-4">{title}</h2>}
+      {children}
+      {actions && <div className="mt-4 flex justify-end gap-2">{actions}</div>}
+    </div>
+  </div>
+);
+
+export default Modal;

--- a/src/components/common/Modal.jsx
+++ b/src/components/common/Modal.jsx
@@ -5,8 +5,14 @@ import React from 'react';
  * Accepts a title, optional actions and an onClose handler.
  */
 const Modal = ({ title, onClose, actions, children }) => (
-  <div className="fixed inset-0 bg-black bg-opacity-40 flex items-center justify-center z-50">
-    <div className="bg-white p-6 rounded shadow max-w-xl w-full max-h-[90vh] overflow-y-auto">
+  <div
+    className="fixed inset-0 bg-black bg-opacity-40 flex items-center justify-center z-50"
+    onClick={onClose}
+  >
+    <div
+      className="bg-white p-6 rounded shadow max-w-xl w-full max-h-[90vh] overflow-y-auto"
+      onClick={(e) => e.stopPropagation()}
+    >
       {title && <h2 className="text-xl font-semibold mb-4">{title}</h2>}
       {children}
       {actions && <div className="mt-4 flex justify-end gap-2">{actions}</div>}

--- a/src/pages/Admission.jsx
+++ b/src/pages/Admission.jsx
@@ -245,6 +245,7 @@ const Admission = () => {
       {actionModal && (
         <Modal
           title={`${actionModal.firstName} ${actionModal.lastName}`}
+          onClose={() => setActionModal(null)}
           actions={
             <>
               <button

--- a/src/pages/Admission.jsx
+++ b/src/pages/Admission.jsx
@@ -5,6 +5,9 @@ import jsPDF from 'jspdf';
 import autoTable from 'jspdf-autotable';
 import * as XLSX from 'xlsx';
 import BASE_URL from '../config';
+import AdmissionForm from '../components/admission/AdmissionForm';
+import AdmissionCard from '../components/admission/AdmissionCard';
+import Modal from '../components/common/Modal';
 
 const Admission = () => {
   const initialForm = {
@@ -218,140 +221,32 @@ const Admission = () => {
       {/* Card View */}
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
         {filteredAdmissions.map((a) => (
-          <div
-            key={a._id}
-            className="bg-white p-4 rounded shadow cursor-pointer hover:ring hover:ring-blue-400"
-            onClick={() => setActionModal(a)}
-          >
-            <div className="font-semibold text-lg">
-              {a.firstName} {a.lastName}
-            </div>
-            <div className="text-gray-600 text-sm">📞 {a.mobileSelf}</div>
-            <div className="text-gray-500 text-xs">
-              {a.course || 'No course selected'}
-            </div>
-          </div>
+          <AdmissionCard key={a._id} data={a} onClick={() => setActionModal(a)} />
         ))}
       </div>
 
       {/* Modal */}
       {showModal && (
-        <div className="fixed inset-0 bg-black bg-opacity-40 flex items-center justify-center z-50">
-          <div className="bg-white p-6 rounded shadow max-w-xl w-full max-h-[90vh] overflow-y-auto">
-            <h2 className="text-2xl font-bold mb-4 text-blue-700">{editingId ? 'Edit Admission' : 'Add New Admission'}</h2>
-            <form onSubmit={handleSubmit} className="flex flex-col gap-3">
-              <input placeholder="First Name" value={form.firstName} onChange={handleChange('firstName')} className="border p-2" required />
-              <input placeholder="Middle Name" value={form.middleName} onChange={handleChange('middleName')} className="border p-2" />
-              <input placeholder="Last Name" value={form.lastName} onChange={handleChange('lastName')} className="border p-2" />
-              <div className="flex items-center gap-4">
-
-                <input type="date"  value={form.dob?.substring(0, 10)}  onChange={handleChange('dob')}
-                  className="border p-2 flex-1"
-                  required
-                /> <label className="w-32 text-sm font-medium">Date of Birth</label>
-              </div>
-
-
-              <div className="flex gap-4">
-                <label><input type="radio" name="gender" value="Male" checked={form.gender === 'Male'} onChange={handleChange('gender')} /> Male</label>
-                <label><input type="radio" name="gender" value="Female" checked={form.gender === 'Female'} onChange={handleChange('gender')} /> Female</label>
-              </div>
-              <input
-                placeholder="Mobile (Self)"
-                value={form.mobileSelf}
-                onChange={handleChange('mobileSelf')}
-                inputMode="numeric"
-                pattern="[0-9]{10}"
-                maxLength={10}
-                className="border p-2"
-              />
-              <input
-                placeholder="Mobile (Parent)"
-                value={form.mobileParent}
-                onChange={handleChange('mobileParent')}
-                inputMode="numeric"
-                pattern="[0-9]{10}"
-                maxLength={10}
-                className="border p-2"
-              />
-              <input placeholder="Address" value={form.address} onChange={handleChange('address')} className="border p-2" />
-
-              <select value={form.education} onChange={handleChange('education')} className="border p-2">
-                <option value="">-- Select Education --</option>
-                {educations.map(e => <option key={e._id} value={e.education}>{e.education}</option>)}
-              </select>
-<select
-                value={form.course}
-                onChange={(e) => {
-                  const selectedCourse = courses.find(c => c.name === e.target.value);
-                  const courseFee = Number(selectedCourse?.courseFees || 0); // ✅ use courseFees
-                  const discount = Number(form.discount || 0);
-                  const feePaid = Number(form.feePaid || 0);
-                  const total = courseFee - discount;
-                  const balance = total - feePaid;
-
-                  setForm(prev => ({
-                    ...prev,
-                    course: e.target.value,
-                    fees: courseFee,
-                    total,
-                    balance
-                  }));
-                }}
-                className="border p-2"
-              >
-                <option value="">-- Select Course --</option>
-                {courses.map(c => (
-                  <option key={c._id} value={c.name}>{c.name}</option>
-                ))}
-              </select>
-              <select value={form.batchTime} onChange={handleChange('batchTime')} className="border p-2">
-                <option value="">-- Select Batch --</option>
-                {batches.map(b => (
-                  <option key={b._id} value={b.time || b.batchTime || b.name || ''}>
-                    {b.time || b.batchTime || b.name || 'Unnamed Batch'}
-                  </option>
-                ))}
-              </select>
-
-              <select value={form.examEvent} onChange={handleChange('examEvent')} className="border p-2">
-                <option value="">-- Select Exam --</option>
-                {exams.map(e => <option key={e._id} value={e.exam}>{e.exam}</option>)}
-              </select>
-
-              
-
-
-              <input placeholder="Installment" value={form.installment} onChange={handleChange('installment')} className="border p-2" />
-              <input placeholder="Fees" value={form.fees} type="number" className="border p-2" readOnly />
-              <input placeholder="Discount" value={form.discount} type="number" onChange={handleChange('discount')} className="border p-2" />
-              <input placeholder="Total" value={form.total} type="number" className="border p-2" readOnly />
-              <input placeholder="Fee Paid" value={form.feePaid} type="number" onChange={handleChange('feePaid')} className="border p-2" />
-
-              <select value={form.paidBy} onChange={handleChange('paidBy')} className="border p-2">
-                <option value="">-- Select Payment Mode --</option>
-                {paymentModes.map(p => <option key={p._id} value={p.mode}>{p.mode}</option>)}
-              </select>
-
-              <input placeholder="Balance" value={form.balance} type="number" className="border p-2" readOnly />
-
-              <div className="flex justify-end gap-2">
-                <button type="button" onClick={() => setShowModal(false)} className="bg-gray-500 text-white px-4 py-2 rounded">Cancel</button>
-                <button type="submit" className="bg-blue-600 text-white px-4 py-2 rounded">{editingId ? 'Update' : 'Submit'}</button>
-              </div>
-            </form>
-          </div>
-        </div>
+        <AdmissionForm
+          form={form}
+          editingId={editingId}
+          educations={educations}
+          courses={courses}
+          exams={exams}
+          batches={batches}
+          paymentModes={paymentModes}
+          onChange={handleChange}
+          onSubmit={handleSubmit}
+          onCancel={() => setShowModal(false)}
+        />
       )}
 
       {/* Action Modal */}
       {actionModal && (
-        <div className="fixed inset-0 bg-black bg-opacity-40 flex items-center justify-center z-50">
-          <div className="bg-white p-6 rounded max-w-sm w-full">
-            <h2 className="text-lg font-bold mb-4">
-              {actionModal.firstName} {actionModal.lastName}
-            </h2>
-            <div className="flex flex-wrap gap-2">
+        <Modal
+          title={`${actionModal.firstName} ${actionModal.lastName}`}
+          actions={
+            <>
               <button
                 onClick={() => {
                   handleEdit(actionModal);
@@ -376,9 +271,11 @@ const Admission = () => {
               >
                 Close
               </button>
-            </div>
-          </div>
-        </div>
+            </>
+          }
+        >
+          <p className="text-sm text-gray-600">Choose an action for this admission.</p>
+        </Modal>
       )}
     </div>
   );


### PR DESCRIPTION
## Summary
- add generic `Modal` component
- split out admission display card and form components
- refactor `Admission` page to use the new reusable components

## Testing
- `npm run build` *(fails: 403 Forbidden when downloading dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685fe976264c8322a7be8cd75f24d147