### PR TITLE
Add EMI start date selection

### DIFF
--- a/src/components/admission/CourseFeeFields.jsx
+++ b/src/components/admission/CourseFeeFields.jsx
@@ -50,6 +50,13 @@ const CourseFeeFields = ({ form, onChange, courses, batches, exams }) => (
       onChange={onChange('installment')}
       className="border p-2"
     />
+    <input
+      type="date"
+      placeholder="EMI Start Date"
+      value={form.emiDate}
+      onChange={onChange('emiDate')}
+      className="border p-2"
+    />
     <input placeholder="Fees" value={form.fees} type="number" className="border p-2" readOnly />
     <input
       placeholder="Discount"

--- a/src/pages/Admission.jsx
+++ b/src/pages/Admission.jsx
@@ -14,6 +14,7 @@ const Admission = () => {
   const initialForm = {
     branchCode: '',
     admissionDate: new Date().toISOString().substring(0, 10),
+    emiDate: new Date(new Date().setMonth(new Date().getMonth() + 1)).toISOString().substring(0,10),
     firstName: '', middleName: '', lastName: '',
     dob: '', gender: '', mobileSelf: '', mobileSelfWhatsapp: false,
     mobileParent: '', mobileParentWhatsapp: false, address: '',
@@ -48,6 +49,20 @@ const Admission = () => {
   const handleChange = (field) => (e) => {
     const value = e.target.type === 'checkbox' ? e.target.checked : e.target.value;
     let updatedForm = { ...form, [field]: value };
+
+    if (field === 'admissionDate') {
+      const d = new Date(value);
+      d.setMonth(d.getMonth() + 1);
+      const nextMonth = d.toISOString().substring(0, 10);
+      const prevDefault = (() => {
+        const pd = new Date(form.admissionDate);
+        pd.setMonth(pd.getMonth() + 1);
+        return pd.toISOString().substring(0, 10);
+      })();
+      if (form.emiDate === prevDefault || form.emiDate === '') {
+        updatedForm.emiDate = nextMonth;
+      }
+    }
 
     const fees = Number(field === 'fees' ? value : form.fees || 0);
     const discount = Number(field === 'discount' ? value : form.discount || 0);

--- a/src/pages/Admission.jsx
+++ b/src/pages/Admission.jsx
@@ -115,7 +115,12 @@ const Admission = () => {
   };
 
   const handleEdit = (data) => {
-    setForm(data);
+    const emiDate = data.emiDate || (() => {
+      const d = new Date(data.admissionDate);
+      d.setMonth(d.getMonth() + 1);
+      return d.toISOString().substring(0, 10);
+    })();
+    setForm({ ...data, emiDate });
     setEditingId(data._id);
     setShowModal(true);
   };

--- a/src/pages/addAdmission.jsx
+++ b/src/pages/addAdmission.jsx
@@ -224,7 +224,12 @@ const AddAdmission = () => {
   };
 
   const handleEdit = (data) => {
-    setForm(data);
+    const emiDate = data.emiDate || (() => {
+      const d = new Date(data.admissionDate);
+      d.setMonth(d.getMonth() + 1);
+      return d.toISOString().substring(0, 10);
+    })();
+    setForm({ ...data, emiDate });
     setInstallmentPlan(data.installmentPlan || []);
     setEditingId(data._id);
     setShowModal(true);


### PR DESCRIPTION
## Summary
- add placeholder for EMI date input in CourseFeeFields
- allow selecting EMI start date in Add Admission page
- keep EMI date synced with admission date when unchanged
- apply same logic in Admission page

## Testing
- `npm run build` *(fails: 403 Forbidden for npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_686011b2ba3c83228d4dee3bc9d8f863