### PR TITLE
Update endpoints to new API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,28 @@
+# SocialFront
+
+Frontend for managing enquiries, admissions, and follow-ups.
+
+## Development
+
+Install dependencies and start the dev server:
+
+```bash
+npm install
+npm run dev
+```
+
+## API Endpoints
+
+The app now consumes the following updated API routes:
+
+- `GET /api/record/enquiry?institute_uuid=ID&page=0&limit=20`
+- `GET /api/record/admission?institute_uuid=ID`
+- `GET /api/record/followup?institute_uuid=ID`
+
+These endpoints return objects of the form:
+
+```json
+{ "data": [], "total": 0, "page": 0, "limit": 20 }
+```
+
+Other record actions like `POST /api/record` and `PUT /api/record/:id` remain unchanged.

--- a/src/Reports/allAdmission.jsx
+++ b/src/Reports/allAdmission.jsx
@@ -87,8 +87,11 @@ const AllAdmission = () => {
   const fetchAdmissions = async () => {
     if (!institute_uuid) return;
     try {
-      const res = await axios.get(`${BASE_URL}/api/record/org/${institute_uuid}?type=admission`);
-      setAdmissions(res.data || []);
+      const res = await axios.get(`${BASE_URL}/api/record/admission`, {
+        params: { institute_uuid }
+      });
+      const { data } = res.data;
+      setAdmissions(Array.isArray(data) ? data : []);
     } catch {
       toast.error('Failed to fetch admissions');
     }

--- a/src/Reports/allEnquiry.jsx
+++ b/src/Reports/allEnquiry.jsx
@@ -28,6 +28,9 @@ const AllEnquiry = () => {
   const [form, setForm] = useState(initialForm);
   const [admissionForm, setAdmissionForm] = useState(admissionTemplate);
   const [enquiries, setEnquiries] = useState([]);
+  const [page, setPage] = useState(0);
+  const [limit, setLimit] = useState(20);
+  const [total, setTotal] = useState(0);
   const [editingId, setEditingId] = useState(null);
   const [showModal, setShowModal] = useState(false);
   const [showAdmission, setShowAdmission] = useState(false);
@@ -63,8 +66,14 @@ const AllEnquiry = () => {
 
   const fetchEnquiries = async () => {
     try {
-      const res = await axios.get(`${BASE_URL}/api/record/org/${institute_uuid}?type=enquiry`);
-      setEnquiries(res.data || []);
+      const res = await axios.get(`${BASE_URL}/api/record/enquiry`, {
+        params: { institute_uuid, page, limit }
+      });
+      const { data, total: t, page: p, limit: l } = res.data;
+      setEnquiries(Array.isArray(data) ? data : []);
+      setTotal(t || 0);
+      setPage(p ?? page);
+      setLimit(l ?? limit);
     } catch {
       toast.error('Failed to fetch enquiries');
     }
@@ -237,7 +246,7 @@ const AllEnquiry = () => {
     fetchExams();
     fetchBatches();
     fetchPaymentModes();
-  }, []);
+  }, [page, limit]);
 
   const filtered = enquiries.filter(e =>
     e.firstName?.toLowerCase().includes(search.toLowerCase()) ||
@@ -298,6 +307,9 @@ const AllEnquiry = () => {
             <div className="text-gray-500 text-xs">{e.course || 'No course selected'}</div>
           </div>
         ))}
+      </div>
+      <div className="text-sm text-gray-800 mt-2">
+        Page {page + 1} - Showing {enquiries.length} of {total}
       </div>
 
       {showModal && (

--- a/src/pages/Enquiry.jsx
+++ b/src/pages/Enquiry.jsx
@@ -11,6 +11,9 @@ const Enquiry = () => {
     course: '',
   });
   const [enquiries, setEnquiries] = useState([]);
+  const [page, setPage] = useState(0);
+  const [limit, setLimit] = useState(20);
+  const [total, setTotal] = useState(0);
   const [selectedEnquiry, setSelectedEnquiry] = useState(null);
   const [showModal, setShowModal] = useState(false);
   const [isEditMode, setIsEditMode] = useState(false);
@@ -23,8 +26,14 @@ const Enquiry = () => {
 
   const fetchEnquiries = async () => {
     try {
-      const res = await axios.get(`${BASE_URL}/api/record/org/${institute_uuid}?type=enquiry`);
-      setEnquiries(res.data || []);
+      const res = await axios.get(`${BASE_URL}/api/record/enquiry`, {
+        params: { institute_uuid, page, limit }
+      });
+      const { data, total: t, page: p, limit: l } = res.data;
+      setEnquiries(Array.isArray(data) ? data : []);
+      setTotal(t || 0);
+      setPage(p ?? page);
+      setLimit(l ?? limit);
     } catch (err) {
       toast.error('Failed to fetch enquiries');
     }
@@ -115,7 +124,7 @@ const Enquiry = () => {
 
   useEffect(() => {
     fetchEnquiries();
-  }, []);
+  }, [page, limit]);
 
   const filtered = enquiries.filter(
     (e) =>
@@ -154,6 +163,9 @@ const Enquiry = () => {
             <div className="text-gray-500 text-xs">{e.course || 'No course selected'}</div>
           </div>
         ))}
+      </div>
+      <div className="text-sm text-gray-600 mt-2">
+        Page {page + 1} - Showing {enquiries.length} of {total}
       </div>
 
       {/* Add/Edit Modal */}

--- a/src/pages/Followup.jsx
+++ b/src/pages/Followup.jsx
@@ -61,8 +61,11 @@ const Followup = () => {
 
   const fetchEnquiries = async () => {
     try {
-      const res = await axios.get(`${BASE_URL}/api/record/${institute_uuid}?type=enquiry`);
-      setEnquiries(res.data || []);
+      const res = await axios.get(`${BASE_URL}/api/record/followup`, {
+        params: { institute_uuid }
+      });
+      const { data } = res.data;
+      setEnquiries(Array.isArray(data) ? data : []);
     } catch {
       toast.error('Failed to fetch enquiries');
     }

--- a/src/pages/oldaddAdmission.jsx
+++ b/src/pages/oldaddAdmission.jsx
@@ -157,8 +157,11 @@ useEffect(() => {
   const fetchAdmissions = async () => {
     if (!institute_uuid) return;
     try {
-      const res = await axios.get(`${BASE_URL}/api/record/org/${institute_uuid}?type=admission`);
-      setAdmissions(res.data || []);
+      const res = await axios.get(`${BASE_URL}/api/record/admission`, {
+        params: { institute_uuid }
+      });
+      const { data } = res.data;
+      setAdmissions(Array.isArray(data) ? data : []);
     } catch {
       toast.error('Failed to fetch admissions');
     }


### PR DESCRIPTION
## Summary
- switch enquiry, admission, and follow-up fetches to new `/api/record/*` routes
- parse `data`, `total`, `page`, and `limit` from the enquiry response
- display page summary below enquiry lists
- document new endpoints in `README.md`

## Testing
- `npm run build` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vite)*

------
https://chatgpt.com/codex/tasks/task_e_6860e28be8ec8322b26fcaf45ea77fe9