### PR TITLE
Enable horizontal scrolling for tables on small screens

### DIFF
--- a/src/Reports/AllTransaction.jsx
+++ b/src/Reports/AllTransaction.jsx
@@ -184,6 +184,7 @@ const AllTransaction = () => {
                     </div>
 
                     {/* Table */}
+                    <div className="overflow-x-auto">
                     <table className="w-full table-auto text-sm border">
                         <thead className="bg-green-100 text-green-900">
                             <tr>

--- a/src/Reports/allAttendance.jsx
+++ b/src/Reports/allAttendance.jsx
@@ -116,7 +116,8 @@ export default function AllAttendance() {
   return (
     
       <div className="bg-white p-4 rounded-2xl shadow flex flex-col items-start">
-        <table className="min-w-full text-sm text-center border">
+      <div className="overflow-x-auto w-full">
+      <table className="min-w-full text-sm text-center border">
           <thead className="bg-gray-100">
             <tr>
               <th className="px-4 py-2 border">Name</th>

--- a/src/components/admissions/AdmissionPaymentInstallmentTab.jsx
+++ b/src/components/admissions/AdmissionPaymentInstallmentTab.jsx
@@ -48,7 +48,8 @@ const AdmissionPaymentInstallmentTab = ({ form, handleChange, installmentPlan, p
       <label className="w-32 text-right">EMI</label>
       <input placeholder="EMI" value={form.emi} type="number" className="border p-2 flex-1" readOnly />
     </div>
-    {installmentPlan.length > 0 && (
+      {installmentPlan.length > 0 && (
+      <div className="overflow-x-auto">
       <table className="w-full border mt-2 text-sm">
         <thead>
           <tr className="bg-gray-100">
@@ -66,8 +67,9 @@ const AdmissionPaymentInstallmentTab = ({ form, handleChange, installmentPlan, p
             </tr>
           ))}
         </tbody>
-      </table>
-    )}
+        </table>
+      </div>
+      )}
   </>
 );
 

--- a/src/components/admissions/ReceiptModal.jsx
+++ b/src/components/admissions/ReceiptModal.jsx
@@ -144,6 +144,7 @@ const ReceiptModal = ({ data, institute = {}, onPrint, onClose }) => {
 
          <div className="bg-gray-100 rounded-md px-4 py-3 mb-2">
           <div className="text-base font-medium">Installment:</div>
+           <div className="overflow-x-auto">
            <table className="w-full border mt-2 text-sm">
         <thead>
           <tr className="bg-gray-100">
@@ -161,8 +162,9 @@ const ReceiptModal = ({ data, institute = {}, onPrint, onClose }) => {
             </tr>
           ))}
         </tbody>
-      </table>
-        </div>
+        </table>
+           </div>
+         </div>
 
         {/* Actions (not shown on print or PDF) */}
         <div className="flex justify-center gap-4 mt-8 no-print">

--- a/src/components/reports/LeadDetailsModal.jsx
+++ b/src/components/reports/LeadDetailsModal.jsx
@@ -85,6 +85,7 @@ const LeadDetailsModal = ({
 
         <div className="bg-gray-100 rounded-md px-4 py-3 mb-2">
           <div className="text-base font-medium">Installment:</div>
+          <div className="overflow-x-auto">
           <table className="w-full border mt-2 text-sm">
             <thead>
               <tr className="bg-gray-100">
@@ -102,7 +103,8 @@ const LeadDetailsModal = ({
                 </tr>
               ))}
             </tbody>
-          </table>
+            </table>
+          </div>
         </div>
 
         <div className="flex gap-2">

--- a/src/pages/Batches.jsx
+++ b/src/pages/Batches.jsx
@@ -105,6 +105,7 @@ const Batches = () => {
         </button>
       </div>
 
+      <div className="overflow-x-auto">
       <table className="w-full border">
         <thead className="bg-gray-100">
           <tr>
@@ -142,6 +143,7 @@ const Batches = () => {
           )}
         </tbody>
       </table>
+      </div>
 
       {showModal && (
         <div className="fixed inset-0 bg-black bg-opacity-40 flex items-center justify-center z-50">

--- a/src/pages/Courses.jsx
+++ b/src/pages/Courses.jsx
@@ -142,6 +142,7 @@ const Courses = () => {
         </div>
       </div>
 
+      <div className="overflow-x-auto">
       <table className="w-full border">
         <thead className="bg-gray-100">
           <tr>
@@ -173,6 +174,7 @@ const Courses = () => {
           ))}
         </tbody>
       </table>
+      </div>
 
       {/* Modal */}
       {showModal && (

--- a/src/pages/CoursesCategory.jsx
+++ b/src/pages/CoursesCategory.jsx
@@ -99,6 +99,7 @@ const CoursesCategory = () => {
         </div>
       </div>
 
+      <div className="overflow-x-auto">
       <table className="w-full border">
         <thead className="bg-gray-100">
           <tr>
@@ -122,6 +123,7 @@ const CoursesCategory = () => {
           ))}
         </tbody>
       </table>
+      </div>
 
       {/* Modal */}
       {showModal && (

--- a/src/pages/Delete.jsx
+++ b/src/pages/Delete.jsx
@@ -605,7 +605,8 @@
                   className="border p-2"
                 />
                 <input placeholder="EMI" value={form.emi} type="number" className="border p-2" readOnly />
-                {installmentPlan.length > 0 && (
+                  {installmentPlan.length > 0 && (
+                  <div className="overflow-x-auto">
                   <table className="w-full border mt-2 text-sm">
                     <thead>
                       <tr className="bg-gray-100">
@@ -624,7 +625,8 @@
                       ))}
                     </tbody>
                   </table>
-                )}
+                  </div>
+                  )}
               </>
             )}
 

--- a/src/pages/Education.jsx
+++ b/src/pages/Education.jsx
@@ -102,6 +102,7 @@ const Education = () => {
         </button>
       </div>
 
+      <div className="overflow-x-auto">
       <table className="w-full border">
         <thead className="bg-gray-100">
           <tr>
@@ -139,6 +140,7 @@ const Education = () => {
           )}
         </tbody>
       </table>
+      </div>
 
       {showModal && (
         <div className="fixed inset-0 bg-black bg-opacity-40 flex items-center justify-center z-50">

--- a/src/pages/Exam.jsx
+++ b/src/pages/Exam.jsx
@@ -102,6 +102,7 @@ const Exam = () => {
         </button>
       </div>
 
+      <div className="overflow-x-auto">
       <table className="w-full border">
         <thead className="bg-gray-100">
           <tr>
@@ -139,6 +140,7 @@ const Exam = () => {
           )}
         </tbody>
       </table>
+      </div>
 
       {showModal && (
         <div className="fixed inset-0 bg-black bg-opacity-40 flex items-center justify-center z-50">

--- a/src/pages/OrgCategories.jsx
+++ b/src/pages/OrgCategories.jsx
@@ -104,6 +104,7 @@ const OrgCategories = () => {
         </button>
       </div>
 
+      <div className="overflow-x-auto">
       <table className="w-full border">
         <thead className="bg-gray-100">
           <tr>
@@ -143,6 +144,7 @@ const OrgCategories = () => {
           )}
         </tbody>
       </table>
+      </div>
 
       {showModal && (
         <div className="fixed inset-0 bg-black bg-opacity-40 flex items-center justify-center z-50">

--- a/src/pages/Owner.jsx
+++ b/src/pages/Owner.jsx
@@ -124,6 +124,7 @@ center_head_name: '',
         </button>
       </div>
 
+      <div className="overflow-x-auto">
       <table className="w-full border border-gray-300 rounded-md">
         <thead>
           <tr className="bg-gray-200 text-center">
@@ -157,6 +158,7 @@ center_head_name: '',
           ))}
         </tbody>
       </table>
+      </div>
 
       {showModal && (
         <div className="fixed inset-0 bg-black bg-opacity-40 flex items-center justify-center z-50">

--- a/src/pages/User.jsx
+++ b/src/pages/User.jsx
@@ -163,6 +163,7 @@ const User = () => {
         </button>
       </div>
 
+      <div className="overflow-x-auto">
       <table className="w-full border border-gray-300 rounded-md">
         <thead>
           <tr className="bg-gray-200 text-center">
@@ -196,6 +197,7 @@ const User = () => {
           ))}
         </tbody>
       </table>
+      </div>
 
       {showModal && (
         <div className="fixed inset-0 bg-black bg-opacity-40 flex items-center justify-center z-50">

--- a/src/pages/remove1.jsx
+++ b/src/pages/remove1.jsx
@@ -102,6 +102,7 @@ const PaymentMode = () => {
         </button>
       </div>
 
+      <div className="overflow-x-auto">
       <table className="w-full border">
         <thead className="bg-gray-100">
           <tr>
@@ -141,6 +142,7 @@ const PaymentMode = () => {
           )}
         </tbody>
       </table>
+      </div>
 
       {/* Modal */}
       {showModal && (


### PR DESCRIPTION
## Summary
- wrap data tables in `<div class="overflow-x-auto">` to prevent horizontal overflow on narrow viewports

## Testing
- `npm test` *(fails: Missing script `test`)*

------
https://chatgpt.com/codex/tasks/task_e_686f7347433c8322bf710d7b11302855