### PR TITLE
Add institutes admin page

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -34,6 +34,7 @@ import AllBatches from './Reports/allBatches';
 import AllBalance from './Reports/allBalance'; // <-- ✅ NEW PAGE
 import AddAccount from './pages/AddAccount';
 import AllExams from './Reports/allExams';
+import Institutes from './pages/Institutes';
 
 export default function App() {
   return (
@@ -59,6 +60,7 @@ export default function App() {
         <Route path="paymentmode" element={<PaymentMode />} />
         <Route path="instituteProfile" element={<InstituteProfile />} />
         <Route path="owner" element={<Owner />} />
+        <Route path="institutes" element={<Institutes />} />
         <Route path="coursesCategory" element={<CoursesCategory />} />
         <Route path="leads" element={<Leads />} />
         <Route path="allAdmission" element={<AllAdmission />} />

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -383,17 +383,29 @@ export default function Navbar({ toggleSidebar }) {
                     </div>
                   )}
 
-                  {user?.role === 'owner' && (
-                    <div
-                      onClick={() => {
-                        navigate('/dashboard/Owner');
-                        setIsOpen(false);
-                      }}
-                      className="flex items-center gap-2 px-3 py-2 rounded hover:bg-gray-100 text-sm cursor-pointer"
-                    >
-                      <EventNoteIcon fontSize="small" />
-                      Owner
-                    </div>
+                  {(user?.role === 'owner' || user?.role === 'super_admin') && (
+                    <>
+                      <div
+                        onClick={() => {
+                          navigate('/dashboard/Owner');
+                          setIsOpen(false);
+                        }}
+                        className="flex items-center gap-2 px-3 py-2 rounded hover:bg-gray-100 text-sm cursor-pointer"
+                      >
+                        <EventNoteIcon fontSize="small" />
+                        Owner
+                      </div>
+                      <div
+                        onClick={() => {
+                          navigate('/dashboard/institutes');
+                          setIsOpen(false);
+                        }}
+                        className="flex items-center gap-2 px-3 py-2 rounded hover:bg-gray-100 text-sm cursor-pointer"
+                      >
+                        <EventNoteIcon fontSize="small" />
+                        Institutes
+                      </div>
+                    </>
                   )}
                 </div>
               )}

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -387,7 +387,7 @@ export default function Navbar({ toggleSidebar }) {
                     <>
                       <div
                         onClick={() => {
-                          navigate('/dashboard/Owner');
+                          navigate('/dashboard/owner');
                           setIsOpen(false);
                         }}
                         className="flex items-center gap-2 px-3 py-2 rounded hover:bg-gray-100 text-sm cursor-pointer"

--- a/src/components/remove4.jsx
+++ b/src/components/remove4.jsx
@@ -41,8 +41,11 @@ export default function Sidebar() {
         ...(userType === 'admin'
           ? [{ path: '/dashboard/instituteProfile', label: 'Profile', icon: <EventNoteIcon fontSize="small" /> }]
           : []),
-        ...(userType === 'owner'
-          ? [{ path: '/dashboard/Owner', label: 'Owner', icon: <EventNoteIcon fontSize="small" /> }]
+        ...(userType === 'owner' || userType === 'super_admin'
+          ? [
+              { path: '/dashboard/Owner', label: 'Owner', icon: <EventNoteIcon fontSize="small" /> },
+              { path: '/dashboard/institutes', label: 'Institutes', icon: <EventNoteIcon fontSize="small" /> }
+            ]
           : [])
       ]
     },

--- a/src/components/remove4.jsx
+++ b/src/components/remove4.jsx
@@ -43,7 +43,7 @@ export default function Sidebar() {
           : []),
         ...(userType === 'owner' || userType === 'super_admin'
           ? [
-              { path: '/dashboard/Owner', label: 'Owner', icon: <EventNoteIcon fontSize="small" /> },
+              { path: '/dashboard/owner', label: 'Owner', icon: <EventNoteIcon fontSize="small" /> },
               { path: '/dashboard/institutes', label: 'Institutes', icon: <EventNoteIcon fontSize="small" /> }
             ]
           : [])

--- a/src/pages/Owner.jsx
+++ b/src/pages/Owner.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react';
 import axios from 'axios';
 import toast, { Toaster } from 'react-hot-toast';
 import { useNavigate } from 'react-router-dom';
+import { useApp } from '../Context/AppContext';
 import BASE_URL from '../config'; // Adjust the path based on your folder structure
 
 
@@ -19,8 +20,15 @@ center_head_name: '',
   const [showModal, setShowModal] = useState(false);
   const [editingId, setEditingId] = useState(null);
   const navigate = useNavigate();
+  const { user } = useApp();
 
   const themeColor = localStorage.getItem('theme_color') || '#d0e0e3';
+
+  useEffect(() => {
+    if (user && user.role !== 'owner' && user.role !== 'super_admin') {
+      navigate('/dashboard');
+    }
+  }, [user, navigate]);
 
   useEffect(() => {
     axios.get(`${BASE_URL}/api/org-categories`)
@@ -82,15 +90,15 @@ center_head_name: '',
     }
   };
 
-  const handleDelete = async (id) => {
-    if (!window.confirm('Are you sure you want to delete this organize?')) return;
+  const handleDelete = async (uuid) => {
+    if (!window.confirm('Are you sure you want to delete this institute and all related data?')) return;
 
     try {
-      await axios.delete(`${BASE_URL}/api/organize/${id}`);
-      toast.success('Organize deleted');
+      await axios.delete(`${BASE_URL}/api/institute/${uuid}`);
+      toast.success('Institute deleted');
       fetchOrgs();
     } catch (error) {
-      toast.error('Error deleting organize');
+      toast.error('Error deleting institute');
     }
   };
 
@@ -131,6 +139,9 @@ center_head_name: '',
             <th className="p-2 border">Name</th>
             <th className="p-2 border">Mobile</th>
             <th className="p-2 border">Head Name</th>
+            <th className="p-2 border">Plan</th>
+            <th className="p-2 border">Start</th>
+            <th className="p-2 border">Expiry</th>
             <th className="p-2 border">Action</th>
           </tr>
         </thead>
@@ -140,6 +151,9 @@ center_head_name: '',
               <td className="p-2 border">{item.institute_title}</td>
               <td className="p-2 border">{item.institute_call_number}</td>
               <td className="p-2 border">{item.center_head_name}</td>
+              <td className="p-2 border">{item.plan_type || 'trial'}</td>
+              <td className="p-2 border">{item.start_date ? new Date(item.start_date).toLocaleDateString() : '-'}</td>
+              <td className="p-2 border">{item.expiry_date ? new Date(item.expiry_date).toLocaleDateString() : '-'}</td>
               <td className="p-2 border space-x-2">
                 <button
                   onClick={() => handleEdit(item)}
@@ -148,7 +162,7 @@ center_head_name: '',
                   Edit
                 </button>
                 <button
-                  onClick={() => handleDelete(item._id)}
+                  onClick={() => handleDelete(item.institute_uuid || item._id)}
                   className="bg-red-500 text-white px-3 py-1 rounded hover:bg-red-600"
                 >
                   Delete


### PR DESCRIPTION
## Summary
- add new `Institutes` page for owners/super admins to manage all institutes
- restrict access to owner pages to owner or super_admin roles
- expose institutes management link in nav/sidebar
- show plan and subscription info on owner list

## Testing
- `npm run build` *(fails: 403 Forbidden - registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_686f7e04dafc8322add7078fc2e3e53a