### PR TITLE
Apply responsive table styling

### DIFF
--- a/src/Reports/AllTransaction.jsx
+++ b/src/Reports/AllTransaction.jsx
@@ -185,13 +185,13 @@ const AllTransaction = () => {
 
                     {/* Table */}
                     <div className="overflow-x-auto">
-                    <table className="w-full table-auto text-sm border">
+                    <table className="min-w-full table-auto text-sm border">
                         <thead className="bg-green-100 text-green-900">
                             <tr>
                                 <th onClick={() => handleSort('name')} className="border px-3 py-2 cursor-pointer text-left">
                                     Customer {sortConfig.key === 'name' && (sortConfig.direction === 'asc' ? <FaSortUp className="inline ml-1" /> : <FaSortDown className="inline ml-1" />)}
                                 </th>
-                                <th onClick={() => handleSort('mobile')} className="border px-3 py-2 cursor-pointer text-left">
+                                <th onClick={() => handleSort('mobile')} className="border px-3 py-2 cursor-pointer text-left hidden md:table-cell">
                                     Mobile {sortConfig.key === 'mobile' && (sortConfig.direction === 'asc' ? <FaSortUp className="inline ml-1" /> : <FaSortDown className="inline ml-1" />)}
                                 </th>
                                 <th onClick={() => handleSort('balance')} className="border px-3 py-2 cursor-pointer text-right">
@@ -208,11 +208,11 @@ const AllTransaction = () => {
                             ) : (
                                 sortedReport.map((item, index) => (
                                     <tr key={index} className="border-t hover:bg-gray-50">
-                                        <td className="px-3 py-2 cursor-pointer text-green-600" onClick={() => viewTransactions(item)}>
+                                        <td className="px-3 py-2 cursor-pointer text-green-600 truncate" onClick={() => viewTransactions(item)}>
                                             {item.name}
                                         </td>
-                                        <td className="px-3 py-2">{item.mobile}</td>
-                                        <td className={`px-3 py-2 text-right ${item.balance < 0 ? 'text-red-600' : 'text-green-700'}`}>
+                                        <td className="px-3 py-2 truncate hidden md:table-cell">{item.mobile}</td>
+                                        <td className={`px-3 py-2 text-right ${item.balance < 0 ? 'text-red-600' : 'text-green-700'} truncate`}>
                                             ₹{Math.abs(item.balance)}
                                         </td>
                                         <td className="px-3 py-2 text-center">

--- a/src/Reports/allAttendance.jsx
+++ b/src/Reports/allAttendance.jsx
@@ -121,8 +121,8 @@ export default function AllAttendance() {
           <tr>
             <th className="px-4 py-2 border">Name</th>
             <th className="px-4 py-2 border">In</th>
-            <th className="px-4 py-2 border">Break</th>
-            <th className="px-4 py-2 border">Start</th>
+            <th className="px-4 py-2 border hidden md:table-cell">Break</th>
+            <th className="px-4 py-2 border hidden md:table-cell">Start</th>
             <th className="px-4 py-2 border">Out</th>
           </tr>
         </thead>
@@ -135,10 +135,10 @@ export default function AllAttendance() {
             attendance.map((record, idx) => (
               <tr key={idx} className="hover:bg-gray-50 border-t">
                 <td className="px-4 py-2 border">{record.User_name}</td>
-                <td className="px-4 py-2 border">{record.In}</td>
-                <td className="px-4 py-2 border">{record.Break}</td>
-                <td className="px-4 py-2 border">{record.Start}</td>
-                <td className="px-4 py-2 border">{record.Out}</td>
+                <td className="px-4 py-2 border truncate">{record.In}</td>
+                <td className="px-4 py-2 border truncate hidden md:table-cell">{record.Break}</td>
+                <td className="px-4 py-2 border truncate hidden md:table-cell">{record.Start}</td>
+                <td className="px-4 py-2 border truncate">{record.Out}</td>
               </tr>
             ))
           )}

--- a/src/Reports/allAttendance.jsx
+++ b/src/Reports/allAttendance.jsx
@@ -146,6 +146,4 @@ export default function AllAttendance() {
       </table>
     </div>
   </div>
-  ); // <-- Add this closing parenthesis and div
-
 }

--- a/src/Reports/allBalance.jsx
+++ b/src/Reports/allBalance.jsx
@@ -141,7 +141,7 @@ const AllBalance = () => {
         <>
             
             
-                <div className="w-full overflow-x-auto pb-2">
+                <div className="min-w-full overflow-x-auto pb-2">
                 
 
 
@@ -180,13 +180,13 @@ const AllBalance = () => {
 
 
                     {/* Table */}
-                    <table className="w-full table-auto text-sm border">
+                    <table className="min-w-full table-auto text-sm border">
                         <thead className="bg-green-100 text-green-900">
                             <tr>
                                 <th onClick={() => handleSort('name')} className="border px-3 py-2 cursor-pointer text-left">
                                     Name {sortConfig.key === 'name' && (sortConfig.direction === 'asc' ? <FaSortUp className="inline ml-1" /> : <FaSortDown className="inline ml-1" />)}
                                 </th>
-                                <th onClick={() => handleSort('mobile')} className="border px-3 py-2 cursor-pointer text-left">
+                                <th onClick={() => handleSort('mobile')} className="border px-3 py-2 cursor-pointer text-left hidden md:table-cell">
                                     Mobile {sortConfig.key === 'mobile' && (sortConfig.direction === 'asc' ? <FaSortUp className="inline ml-1" /> : <FaSortDown className="inline ml-1" />)}
                                 </th>
                                 <th className="border px-3 py-2 text-right">Receivable</th>
@@ -202,14 +202,14 @@ const AllBalance = () => {
                             ) : (
                                 sortedReport.map((item, index) => (
                                     <tr key={index} className="border-t hover:bg-gray-50">
-                                        <td className="px-3 py-2 cursor-pointer text-green-600" onClick={() => viewTransactions(item)}>
+                                        <td className="px-3 py-2 cursor-pointer text-green-600 truncate" onClick={() => viewTransactions(item)}>
                                             {item.name}
                                         </td>
-                                        <td className="px-3 py-2">{item.mobile}</td>
-                                        <td className="px-3 py-2 text-right text-green-700">
+                                        <td className="px-3 py-2 truncate hidden md:table-cell">{item.mobile}</td>
+                                        <td className="px-3 py-2 text-right text-green-700 truncate">
                                             {item.balance > 0 ? `₹${item.balance}` : '-'}
                                         </td>
-                                        <td className="px-3 py-2 text-right text-red-600">
+                                        <td className="px-3 py-2 text-right text-red-600 truncate">
                                             {item.balance < 0 ? `₹${Math.abs(item.balance)}` : '-'}
                                         </td>
                                         <td className="px-3 py-2 text-center"></td>

--- a/src/components/admissions/AdmissionPaymentInstallmentTab.jsx
+++ b/src/components/admissions/AdmissionPaymentInstallmentTab.jsx
@@ -50,7 +50,7 @@ const AdmissionPaymentInstallmentTab = ({ form, handleChange, installmentPlan, p
     </div>
       {installmentPlan.length > 0 && (
       <div className="overflow-x-auto">
-      <table className="w-full border mt-2 text-sm">
+      <table className="min-w-full border mt-2 text-sm">
         <thead>
           <tr className="bg-gray-100">
             <th className="border px-2 py-1">#</th>
@@ -61,9 +61,9 @@ const AdmissionPaymentInstallmentTab = ({ form, handleChange, installmentPlan, p
         <tbody>
           {installmentPlan.map(p => (
             <tr key={p.installmentNo}>
-              <td className="border px-2 py-1 text-center">{p.installmentNo}</td>
-              <td className="border px-2 py-1">{p.dueDate}</td>
-              <td className="border px-2 py-1 text-right">{p.amount}</td>
+              <td className="border px-2 py-1 text-center truncate">{p.installmentNo}</td>
+              <td className="border px-2 py-1 truncate">{p.dueDate}</td>
+              <td className="border px-2 py-1 text-right truncate">{p.amount}</td>
             </tr>
           ))}
         </tbody>

--- a/src/components/admissions/ReceiptModal.jsx
+++ b/src/components/admissions/ReceiptModal.jsx
@@ -145,7 +145,7 @@ const ReceiptModal = ({ data, institute = {}, onPrint, onClose }) => {
          <div className="bg-gray-100 rounded-md px-4 py-3 mb-2">
           <div className="text-base font-medium">Installment:</div>
            <div className="overflow-x-auto">
-           <table className="w-full border mt-2 text-sm">
+           <table className="min-w-full border mt-2 text-sm">
         <thead>
           <tr className="bg-gray-100">
             <th className="border px-2 py-1">#</th>
@@ -156,9 +156,9 @@ const ReceiptModal = ({ data, institute = {}, onPrint, onClose }) => {
         <tbody>
           {fields.installmentPlan.map(p => (
             <tr key={p.installmentNo}>
-              <td className="border px-2 py-1 text-center">{p.installmentNo}</td>
-              <td className="border px-2 py-1">{p.dueDate}</td>
-              <td className="border px-2 py-1 text-right">{p.amount}</td>
+              <td className="border px-2 py-1 text-center truncate">{p.installmentNo}</td>
+              <td className="border px-2 py-1 truncate">{p.dueDate}</td>
+              <td className="border px-2 py-1 text-right truncate">{p.amount}</td>
             </tr>
           ))}
         </tbody>

--- a/src/components/reports/LeadDetailsModal.jsx
+++ b/src/components/reports/LeadDetailsModal.jsx
@@ -86,7 +86,7 @@ const LeadDetailsModal = ({
         <div className="bg-gray-100 rounded-md px-4 py-3 mb-2">
           <div className="text-base font-medium">Installment:</div>
           <div className="overflow-x-auto">
-          <table className="w-full border mt-2 text-sm">
+          <table className="min-w-full border mt-2 text-sm">
             <thead>
               <tr className="bg-gray-100">
                 <th className="border px-2 py-1">#</th>
@@ -97,9 +97,9 @@ const LeadDetailsModal = ({
             <tbody>
               {(receiptInfo.installmentPlan || []).map((p) => (
                 <tr key={p.installmentNo}>
-                  <td className="border px-2 py-1 text-center">{p.installmentNo}</td>
-                  <td className="border px-2 py-1">{p.dueDate}</td>
-                  <td className="border px-2 py-1 text-right">{p.amount}</td>
+                  <td className="border px-2 py-1 text-center truncate">{p.installmentNo}</td>
+                  <td className="border px-2 py-1 truncate">{p.dueDate}</td>
+                  <td className="border px-2 py-1 text-right truncate">{p.amount}</td>
                 </tr>
               ))}
             </tbody>

--- a/src/pages/AddAttendance.jsx
+++ b/src/pages/AddAttendance.jsx
@@ -202,8 +202,8 @@ export default function AddAttendance() {
                             <thead className="bg-gray-100">
                                 <tr>
                                     <th className="px-4 py-2 border">In</th>
-                                    <th className="px-4 py-2 border">Lunch</th>
-                                    <th className="px-4 py-2 border">Start</th>
+                                    <th className="px-4 py-2 border hidden md:table-cell">Lunch</th>
+                                    <th className="px-4 py-2 border hidden md:table-cell">Start</th>
                                     <th className="px-4 py-2 border">Out</th>
                                 </tr>
                             </thead>
@@ -215,10 +215,10 @@ export default function AddAttendance() {
                                 ) : (
                                     attendance.map((record, index) => (
                                         <tr key={index} className="hover:bg-gray-50 border-t">
-                                            <td className="px-4 py-2 border">{record.In}</td>
-                                            <td className="px-4 py-2 border">{record.Break}</td>
-                                            <td className="px-4 py-2 border">{record.Start}</td>
-                                            <td className="px-4 py-2 border">{record.Out}</td>
+                                            <td className="px-4 py-2 border truncate">{record.In}</td>
+                                            <td className="px-4 py-2 border truncate hidden md:table-cell">{record.Break}</td>
+                                            <td className="px-4 py-2 border truncate hidden md:table-cell">{record.Start}</td>
+                                            <td className="px-4 py-2 border truncate">{record.Out}</td>
                                         </tr>
                                     ))
                                 )}

--- a/src/pages/Batches.jsx
+++ b/src/pages/Batches.jsx
@@ -106,11 +106,11 @@ const Batches = () => {
       </div>
 
       <div className="overflow-x-auto">
-      <table className="w-full border">
+      <table className="min-w-full border">
         <thead className="bg-gray-100">
           <tr>
             <th className="p-2 border">Name</th>
-            <th className="p-2 border">Timing</th>
+            <th className="p-2 border hidden md:table-cell">Timing</th>
             <th className="p-2 border">Action</th>
           </tr>
         </thead>
@@ -122,8 +122,8 @@ const Batches = () => {
           ) : (
             filtered.map((b) => (
               <tr key={b._id} className="text-center hover:bg-gray-100 transition">
-                <td className="border p-2">{b.name}</td>
-                <td className="border p-2">{b.timing}</td>
+                <td className="border p-2 truncate">{b.name}</td>
+                <td className="border p-2 truncate hidden md:table-cell">{b.timing}</td>
                 <td className="border p-2">
                   <button
                     onClick={() => handleEdit(b)}

--- a/src/pages/Courses.jsx
+++ b/src/pages/Courses.jsx
@@ -143,13 +143,13 @@ const Courses = () => {
       </div>
 
       <div className="overflow-x-auto">
-      <table className="w-full border">
+      <table className="min-w-full border">
         <thead className="bg-gray-100">
           <tr>
             <th className="p-2 border">Name</th>
-            <th className="p-2 border">Description</th>
+            <th className="p-2 border hidden md:table-cell">Description</th>
             <th className="p-2 border">Course Fees</th>
-            <th className="p-2 border">Exam Fees</th>
+            <th className="p-2 border hidden md:table-cell">Exam Fees</th>
             <th className="p-2 border">Duration</th>
             <th className="p-2 border">Action</th>
           </tr>
@@ -157,10 +157,10 @@ const Courses = () => {
         <tbody>
           {filteredCourses.map((c, i) => (
             <tr key={i} className="text-center">
-              <td className="border p-2">{c.name}</td>
-              <td className="border p-2">{c.description}</td>
+              <td className="border p-2 truncate">{c.name}</td>
+              <td className="border p-2 truncate hidden md:table-cell">{c.description}</td>
               <td className="border p-2">{c.courseFees}</td>
-              <td className="border p-2">{c.examFees}</td>
+              <td className="border p-2 truncate hidden md:table-cell">{c.examFees}</td>
               <td className="border p-2">{c.duration}</td>
               <td className="border p-2 space-x-2">
                 <button onClick={() => handleEdit(c)} className="bg-yellow-500 text-white px-2 py-1 rounded" title="Edit">

--- a/src/pages/CoursesCategory.jsx
+++ b/src/pages/CoursesCategory.jsx
@@ -100,7 +100,7 @@ const CoursesCategory = () => {
       </div>
 
       <div className="overflow-x-auto">
-      <table className="w-full border">
+      <table className="min-w-full border">
         <thead className="bg-gray-100">
           <tr>
             <th className="p-2 border">Name</th>
@@ -110,7 +110,7 @@ const CoursesCategory = () => {
         <tbody>
           {filteredCourses.map((c, i) => (
             <tr key={i} className="text-center">
-              <td className="border p-2">{c.name}</td>
+              <td className="border p-2 truncate">{c.name}</td>
               <td className="border p-2 space-x-2">
                 <button onClick={() => handleEdit(c)} className="bg-yellow-500 text-white px-2 py-1 rounded" title="Edit">
                   <Edit fontSize="small" />

--- a/src/pages/Delete.jsx
+++ b/src/pages/Delete.jsx
@@ -607,7 +607,7 @@
                 <input placeholder="EMI" value={form.emi} type="number" className="border p-2" readOnly />
                   {installmentPlan.length > 0 && (
                   <div className="overflow-x-auto">
-                  <table className="w-full border mt-2 text-sm">
+                  <table className="min-w-full border mt-2 text-sm">
                     <thead>
                       <tr className="bg-gray-100">
                         <th className="border px-2 py-1">#</th>
@@ -618,9 +618,9 @@
                     <tbody>
                       {installmentPlan.map(p => (
                         <tr key={p.installmentNo}>
-                          <td className="border px-2 py-1 text-center">{p.installmentNo}</td>
-                          <td className="border px-2 py-1">{p.dueDate}</td>
-                          <td className="border px-2 py-1 text-right">{p.amount}</td>
+                          <td className="border px-2 py-1 text-center truncate">{p.installmentNo}</td>
+                          <td className="border px-2 py-1 truncate">{p.dueDate}</td>
+                          <td className="border px-2 py-1 text-right truncate">{p.amount}</td>
                         </tr>
                       ))}
                     </tbody>

--- a/src/pages/Education.jsx
+++ b/src/pages/Education.jsx
@@ -103,11 +103,11 @@ const Education = () => {
       </div>
 
       <div className="overflow-x-auto">
-      <table className="w-full border">
+      <table className="min-w-full border">
         <thead className="bg-gray-100">
           <tr>
             <th className="p-2 border">Education</th>
-            <th className="p-2 border">Description</th>
+            <th className="p-2 border hidden md:table-cell">Description</th>
             <th className="p-2 border">Action</th>
           </tr>
         </thead>
@@ -119,8 +119,8 @@ const Education = () => {
           ) : (
             filtered.map(item => (
               <tr key={item._id} className="text-center hover:bg-gray-100 transition">
-                <td className="border p-2">{item.education}</td>
-                <td className="border p-2">{item.description}</td>
+                <td className="border p-2 truncate">{item.education}</td>
+                <td className="border p-2 truncate hidden md:table-cell">{item.description}</td>
                 <td className="border p-2">
                   <button
                     onClick={() => handleEdit(item)}

--- a/src/pages/Exam.jsx
+++ b/src/pages/Exam.jsx
@@ -103,11 +103,11 @@ const Exam = () => {
       </div>
 
       <div className="overflow-x-auto">
-      <table className="w-full border">
+      <table className="min-w-full border">
         <thead className="bg-gray-100">
           <tr>
             <th className="p-2 border">Exam</th>
-            <th className="p-2 border">Description</th>
+            <th className="p-2 border hidden md:table-cell">Description</th>
             <th className="p-2 border">Action</th>
           </tr>
         </thead>
@@ -119,8 +119,8 @@ const Exam = () => {
           ) : (
             filtered.map(item => (
               <tr key={item._id} className="text-center hover:bg-gray-100 transition">
-                <td className="border p-2">{item.exam}</td>
-                <td className="border p-2">{item.description}</td>
+                <td className="border p-2 truncate">{item.exam}</td>
+                <td className="border p-2 truncate hidden md:table-cell">{item.description}</td>
                 <td className="border p-2">
                   <button
                     onClick={() => handleEdit(item)}

--- a/src/pages/Institutes.jsx
+++ b/src/pages/Institutes.jsx
@@ -53,12 +53,12 @@ const Institutes = () => {
       <Toaster position="top-right" />
       <h1 className="text-3xl font-bold text-gray-800 mb-4">Manage Institutes</h1>
       <div className="overflow-x-auto">
-        <table className="w-full border border-gray-300 rounded-md">
+        <table className="min-w-full border border-gray-300 rounded-md">
           <thead>
             <tr className="bg-gray-200 text-center text-sm">
               <th className="p-2 border">Name</th>
-              <th className="p-2 border">Center Code</th>
-              <th className="p-2 border">Plan</th>
+              <th className="p-2 border hidden md:table-cell">Center Code</th>
+              <th className="p-2 border hidden md:table-cell">Plan</th>
               <th className="p-2 border">Start Date</th>
               <th className="p-2 border">Expiry</th>
               <th className="p-2 border">Action</th>
@@ -67,9 +67,9 @@ const Institutes = () => {
           <tbody>
             {institutes.map((inst) => (
               <tr key={inst.institute_uuid || inst._id} className="text-center text-sm">
-                <td className="p-2 border">{inst.institute_title}</td>
-                <td className="p-2 border">{inst.center_code}</td>
-                <td className="p-2 border">{inst.plan_type || 'trial'}</td>
+                <td className="p-2 border truncate">{inst.institute_title}</td>
+                <td className="p-2 border truncate hidden md:table-cell">{inst.center_code}</td>
+                <td className="p-2 border truncate hidden md:table-cell">{inst.plan_type || 'trial'}</td>
                 <td className="p-2 border">{inst.start_date ? new Date(inst.start_date).toLocaleDateString() : '-'}</td>
                 <td className="p-2 border">{inst.expiry_date ? new Date(inst.expiry_date).toLocaleDateString() : '-'}</td>
                 <td className="p-2 border space-x-2">

--- a/src/pages/OrgCategories.jsx
+++ b/src/pages/OrgCategories.jsx
@@ -105,11 +105,11 @@ const OrgCategories = () => {
       </div>
 
       <div className="overflow-x-auto">
-      <table className="w-full border">
+      <table className="min-w-full border">
         <thead className="bg-gray-100">
           <tr>
             <th className="p-2 border">Category</th>
-            <th className="p-2 border">Description</th>
+            <th className="p-2 border hidden md:table-cell">Description</th>
             <th className="p-2 border">Action</th>
           </tr>
         </thead>
@@ -123,8 +123,8 @@ const OrgCategories = () => {
           ) : (
             filtered.map((c) => (
               <tr key={c._id} className="text-center hover:bg-gray-100 transition">
-                <td className="border p-2">{c.category}</td>
-                <td className="border p-2">{c.description}</td>
+                <td className="border p-2 truncate">{c.category}</td>
+                <td className="border p-2 truncate hidden md:table-cell">{c.description}</td>
                 <td className="border p-2">
                   <button
                     onClick={() => handleEdit(c)}

--- a/src/pages/Owner.jsx
+++ b/src/pages/Owner.jsx
@@ -133,13 +133,13 @@ center_head_name: '',
       </div>
 
       <div className="overflow-x-auto">
-      <table className="w-full border border-gray-300 rounded-md">
+      <table className="min-w-full border border-gray-300 rounded-md">
         <thead>
           <tr className="bg-gray-200 text-center">
             <th className="p-2 border">Name</th>
-            <th className="p-2 border">Mobile</th>
+            <th className="p-2 border hidden md:table-cell">Mobile</th>
             <th className="p-2 border">Head Name</th>
-            <th className="p-2 border">Plan</th>
+            <th className="p-2 border hidden md:table-cell">Plan</th>
             <th className="p-2 border">Start</th>
             <th className="p-2 border">Expiry</th>
             <th className="p-2 border">Action</th>
@@ -148,10 +148,10 @@ center_head_name: '',
         <tbody>
           {orgs.map((item, idx) => (
             <tr key={idx} className="text-center">
-              <td className="p-2 border">{item.institute_title}</td>
-              <td className="p-2 border">{item.institute_call_number}</td>
-              <td className="p-2 border">{item.center_head_name}</td>
-              <td className="p-2 border">{item.plan_type || 'trial'}</td>
+              <td className="p-2 border truncate">{item.institute_title}</td>
+              <td className="p-2 border truncate hidden md:table-cell">{item.institute_call_number}</td>
+              <td className="p-2 border truncate">{item.center_head_name}</td>
+              <td className="p-2 border truncate hidden md:table-cell">{item.plan_type || 'trial'}</td>
               <td className="p-2 border">{item.start_date ? new Date(item.start_date).toLocaleDateString() : '-'}</td>
               <td className="p-2 border">{item.expiry_date ? new Date(item.expiry_date).toLocaleDateString() : '-'}</td>
               <td className="p-2 border space-x-2">

--- a/src/pages/User.jsx
+++ b/src/pages/User.jsx
@@ -164,11 +164,11 @@ const User = () => {
       </div>
 
       <div className="overflow-x-auto">
-      <table className="w-full border border-gray-300 rounded-md">
+      <table className="min-w-full border border-gray-300 rounded-md">
         <thead>
           <tr className="bg-gray-200 text-center">
             <th className="p-2 border">Name</th>
-            <th className="p-2 border">Mobile</th>
+            <th className="p-2 border hidden md:table-cell">Mobile</th>
             <th className="p-2 border">Type</th>
             <th className="p-2 border">Action</th>
           </tr>
@@ -176,9 +176,9 @@ const User = () => {
         <tbody>
           {users.map((item) => (
             <tr key={item._id} className="text-center">
-              <td className="p-2 border">{item.name}</td>
-              <td className="p-2 border">{item.mobile}</td>
-              <td className="p-2 border">{item.role}</td>
+              <td className="p-2 border truncate">{item.name}</td>
+              <td className="p-2 border truncate hidden md:table-cell">{item.mobile}</td>
+              <td className="p-2 border truncate">{item.role}</td>
               <td className="p-2 border space-x-2">
                 <button
                   onClick={() => handleEdit(item)}

--- a/src/pages/remove1.jsx
+++ b/src/pages/remove1.jsx
@@ -103,12 +103,12 @@ const PaymentMode = () => {
       </div>
 
       <div className="overflow-x-auto">
-      <table className="w-full border">
+      <table className="min-w-full border">
         <thead className="bg-gray-100">
           <tr>
             
             <th className="p-2 border">Mode</th>
-            <th className="p-2 border">Description</th>
+            <th className="p-2 border hidden md:table-cell">Description</th>
             <th className="p-2 border">Action</th>
           </tr>
         </thead>
@@ -121,8 +121,8 @@ const PaymentMode = () => {
             filtered.map((item) => (
               <tr key={item._id} className="text-center hover:bg-gray-100 transition">
                 
-                <td className="border p-2">{item.mode}</td>
-                <td className="border p-2">{item.description}</td>
+                <td className="border p-2 truncate">{item.mode}</td>
+                <td className="border p-2 truncate hidden md:table-cell">{item.description}</td>
                 <td className="border p-2">
                   <button
                     onClick={() => handleEdit(item)}


### PR DESCRIPTION
## Summary
- ensure every table uses `overflow-x-auto` wrapper
- apply `min-w-full` to tables
- truncate long table data
- hide some columns on small screens

## Testing
- `npm run build` *(fails: 403 Forbidden for npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_686f81d9945483229a169b3f238fa60c