### PR TITLE
Apply default theme color fallback

### DIFF
--- a/src/components/ResetPassword.jsx
+++ b/src/components/ResetPassword.jsx
@@ -3,11 +3,12 @@ import { useParams, useNavigate } from 'react-router-dom';
 import axios from 'axios';
 import toast, { Toaster } from 'react-hot-toast';
 import BASE_URL from '../config';
+import { getThemeColor } from '../utils/storageUtils';
 
 const ResetPassword = () => {
   const { id } = useParams();
   const navigate = useNavigate();
-  const themeColor = localStorage.getItem('theme_color') || '#d0e0e3';
+  const themeColor = getThemeColor();
 
   const [oldPassword, setOldPassword] = useState('');
   const [newPassword, setNewPassword] = useState('');

--- a/src/components/admissions/useAdmissionForm.js
+++ b/src/components/admissions/useAdmissionForm.js
@@ -7,6 +7,7 @@ import jsPDF from 'jspdf';
 import autoTable from 'jspdf-autotable';
 import * as XLSX from 'xlsx';
 import BASE_URL from '../../config';
+import { getThemeColor } from '../../utils/storageUtils';
 
 const useAdmissionForm = (initialForm = {}) => {
   const navigate = useNavigate();
@@ -59,7 +60,7 @@ const useAdmissionForm = (initialForm = {}) => {
 
   const [installmentPlan, setInstallmentPlan] = useState([]);
 
-  const themeColor = localStorage.getItem('theme_color') || '#d0e0e3';
+  const themeColor = getThemeColor();
   const institute_uuid = localStorage.getItem('institute_uuid');
   const [searchParams] = useSearchParams();
   const lead_uuid = searchParams.get('lead_uuid');

--- a/src/index.css
+++ b/src/index.css
@@ -9,5 +9,5 @@
 
 body {
   font-family: 'Inter', sans-serif;
-  background-color: #f9f9f9;
+  background-color: var(--theme-color, #d0e0e3);
 }

--- a/src/pages/Batches.jsx
+++ b/src/pages/Batches.jsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useRef } from 'react';
 import axios from 'axios';
 import toast, { Toaster } from 'react-hot-toast';
 import BASE_URL from '../config';
+import { getThemeColor } from '../utils/storageUtils';
 
 const Batches = () => {
   const [batches, setBatches] = useState([]);
@@ -16,7 +17,7 @@ const Batches = () => {
   const searchTimeout = useRef();
 
   const institute_id = localStorage.getItem('institute_uuid');
-  const themeColor = localStorage.getItem('theme_color') || '';
+  const themeColor = getThemeColor();
 
   const fetchBatches = async () => {
     try {

--- a/src/pages/Courses.jsx
+++ b/src/pages/Courses.jsx
@@ -6,6 +6,7 @@ import autoTable from 'jspdf-autotable';
 import * as XLSX from 'xlsx';
 import { Edit, Delete, Add, PictureAsPdf, FileDownload } from '@mui/icons-material';
 import BASE_URL from '../config';
+import { getThemeColor } from '../utils/storageUtils';
 
 const Courses = () => {
   const [courses, setCourses] = useState([]);
@@ -22,7 +23,7 @@ const Courses = () => {
   const [debouncedSearch, setDebouncedSearch] = useState('');
   const [loading, setLoading] = useState(true);
   const searchTimeout = useRef();
-  const themeColor = localStorage.getItem('theme_color') || '#d0e0e3';
+  const themeColor = getThemeColor();
 
   // Debounced search
   useEffect(() => {

--- a/src/pages/CoursesCategory.jsx
+++ b/src/pages/CoursesCategory.jsx
@@ -6,6 +6,7 @@ import autoTable from 'jspdf-autotable';
 import * as XLSX from 'xlsx';
 import { Edit, Delete, Add, PictureAsPdf, FileDownload } from '@mui/icons-material';
 import BASE_URL from '../config';
+import { getThemeColor } from '../utils/storageUtils';
 
 const CoursesCategory = () => {
   const [courses, setCourses] = useState([]);
@@ -15,7 +16,7 @@ const CoursesCategory = () => {
   const [editingId, setEditingId] = useState(null);
   const [showModal, setShowModal] = useState(false);
   const [search, setSearch] = useState('');
-  const themeColor = localStorage.getItem('theme_color') || '#d0e0e3';
+  const themeColor = getThemeColor();
 
   const fetchCourses = async () => {
     try {

--- a/src/pages/Delete.jsx
+++ b/src/pages/Delete.jsx
@@ -5,7 +5,8 @@
   import jsPDF from 'jspdf';
   import autoTable from 'jspdf-autotable';
   import * as XLSX from 'xlsx';
-  import BASE_URL from '../config';
+import BASE_URL from '../config';
+import { getThemeColor } from '../utils/storageUtils';
 
   const AddAdmission = () => {
     const nextMonthDate = (() => {
@@ -55,7 +56,7 @@
     const [educations, setEducations] = useState([]);
     const [exams, setExams] = useState([]);
     const [batches, setBatches] = useState([]);
-    const themeColor = localStorage.getItem('theme_color') || '#d0e0e3';
+    const themeColor = getThemeColor();
     const [paymentModes, setPaymentModes] = useState([]);
     const [installmentPlan, setInstallmentPlan] = useState([]);
 

--- a/src/pages/Education.jsx
+++ b/src/pages/Education.jsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useRef } from 'react';
 import axios from 'axios';
 import toast, { Toaster } from 'react-hot-toast';
 import BASE_URL from '../config';
+import { getThemeColor } from '../utils/storageUtils';
 
 const Education = () => {
   const [list, setList] = useState([]);
@@ -11,7 +12,7 @@ const Education = () => {
   const [search, setSearch] = useState('');
   const [loading, setLoading] = useState(false);
   const inputRef = useRef();
-  const themeColor = localStorage.getItem('theme_color') || '#d0e0e3';
+  const themeColor = getThemeColor();
 
   const fetchData = async () => {
     try {

--- a/src/pages/Exam.jsx
+++ b/src/pages/Exam.jsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useRef } from 'react';
 import axios from 'axios';
 import toast, { Toaster } from 'react-hot-toast';
 import BASE_URL from '../config';
+import { getThemeColor } from '../utils/storageUtils';
 
 const Exam = () => {
   const [list, setList] = useState([]);
@@ -14,7 +15,7 @@ const Exam = () => {
   const [fetchLoading, setFetchLoading] = useState(true);
   const inputRef = useRef();
   const searchTimeout = useRef();
-  const themeColor = localStorage.getItem('theme_color') || '#d0e0e3';
+  const themeColor = getThemeColor();
 
   const fetchData = async () => {
     try {

--- a/src/pages/Institutes.jsx
+++ b/src/pages/Institutes.jsx
@@ -4,6 +4,7 @@ import toast, { Toaster } from 'react-hot-toast';
 import { useNavigate } from 'react-router-dom';
 import { useApp } from '../Context/AppContext';
 import BASE_URL from '../config';
+import { getThemeColor } from '../utils/storageUtils';
 
 const Institutes = () => {
   const { user } = useApp();
@@ -46,7 +47,7 @@ const Institutes = () => {
     }
   };
 
-  const themeColor = localStorage.getItem('theme_color') || '#d0e0e3';
+  const themeColor = getThemeColor();
 
   return (
     <div className="min-h-screen p-6" style={{ backgroundColor: themeColor }}>

--- a/src/pages/OrgCategories.jsx
+++ b/src/pages/OrgCategories.jsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useRef } from 'react';
 import axios from 'axios';
 import toast, { Toaster } from 'react-hot-toast';
 import BASE_URL from '../config';
+import { getThemeColor } from '../utils/storageUtils';
 
 const OrgCategories = () => {
   const [categories, setCategories] = useState([]);
@@ -11,7 +12,7 @@ const OrgCategories = () => {
   const [search, setSearch] = useState('');
   const [loading, setLoading] = useState(false);
   const categoryInputRef = useRef();
-  const themeColor = localStorage.getItem('theme_color') || '#d0e0e3';
+  const themeColor = getThemeColor();
 
   const fetchCategories = async () => {
     try {

--- a/src/pages/Owner.jsx
+++ b/src/pages/Owner.jsx
@@ -4,6 +4,7 @@ import toast, { Toaster } from 'react-hot-toast';
 import { useNavigate } from 'react-router-dom';
 import { useApp } from '../Context/AppContext';
 import BASE_URL from '../config'; // Adjust the path based on your folder structure
+import { getThemeColor } from '../utils/storageUtils';
 
 
 const Owner = () => {
@@ -22,7 +23,7 @@ center_head_name: '',
   const navigate = useNavigate();
   const { user } = useApp();
 
-  const themeColor = localStorage.getItem('theme_color') || '#d0e0e3';
+  const themeColor = getThemeColor();
 
   useEffect(() => {
     if (user && user.role !== 'owner' && user.role !== 'super_admin') {

--- a/src/pages/remove.jsx
+++ b/src/pages/remove.jsx
@@ -10,6 +10,7 @@ import autoTable from 'jspdf-autotable';
 import * as XLSX from 'xlsx';
 
 import BASE_URL from '../config';
+import { getThemeColor } from '../utils/storageUtils';
 import { useMetadata } from '../Context/MetadataContext';
 
 const Followup = () => {
@@ -38,7 +39,7 @@ const Followup = () => {
   const [search, setSearch] = useState('');
   const [actionModal, setActionModal] = useState(null);
   const institute_uuid = localStorage.getItem('institute_uuid');
-  const themeColor = localStorage.getItem('theme_color') || '#d0e0e3';
+  const themeColor = getThemeColor();
 
   const handleChange = (field) => (e) => {
     const value = e.target.type === 'checkbox' ? e.target.checked : e.target.value;

--- a/src/pages/remove1.jsx
+++ b/src/pages/remove1.jsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useRef } from 'react';
 import axios from 'axios';
 import toast, { Toaster } from 'react-hot-toast';
 import BASE_URL from '../config';
+import { getThemeColor } from '../utils/storageUtils';
 
 const PaymentMode = () => {
   const [list, setList] = useState([]);
@@ -11,7 +12,7 @@ const PaymentMode = () => {
   const [search, setSearch] = useState('');
   const [loading, setLoading] = useState(false);
   const inputRef = useRef();
-  const themeColor = localStorage.getItem('theme_color') || '#d0e0e3';
+  const themeColor = getThemeColor();
 
   const fetchData = async () => {
     try {

--- a/src/utils/storageUtils.js
+++ b/src/utils/storageUtils.js
@@ -84,3 +84,11 @@ export const getStoredUser = () => {
     return null;
   }
 };
+
+/**
+ * Retrieve the current theme color from localStorage.
+ * Falls back to '#d0e0e3' when none is stored.
+ */
+export const getThemeColor = () => {
+  return localStorage.getItem('theme_color') || '#d0e0e3';
+};

--- a/src/utils/storageUtils.js
+++ b/src/utils/storageUtils.js
@@ -90,5 +90,7 @@ export const getStoredUser = () => {
  * Falls back to '#d0e0e3' when none is stored.
  */
 export const getThemeColor = () => {
-  return localStorage.getItem('theme_color') || '#d0e0e3';
+  const color = localStorage.getItem('theme_color') || '#d0e0e3';
+  document.documentElement.style.setProperty('--theme-color', color);
+  return color;
 };


### PR DESCRIPTION
## Summary
- provide a helper to fetch the theme color with a fallback
- use the helper in pages and components
- use CSS variable for page background

## Testing
- `npm run build` *(fails: 403 Forbidden; no network access)*

------
https://chatgpt.com/codex/tasks/task_e_686fa1e3b6bc83228fe4956c1fa104dd