### PR TITLE
UI enhancements and automation updates

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
   <meta charset="UTF-8" />
-  <link rel="icon" href="/favicon.ico" />
+  <link rel="icon" href="/icon.svg" />
   <link
   rel="stylesheet"
   href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css"

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -37,6 +37,7 @@ import AllExams from './reports/allExams';
 import Institutes from './pages/Institutes';
 import Students from './pages/Students';
 import Fees from './pages/Fees';
+import ToolsPanel from './pages/ToolsPanel';
 
 export default function App() {
   return (
@@ -79,8 +80,9 @@ export default function App() {
         <Route path="allBalance" element={<AllBalance />} /> {/* ✅ Added Route */}
         <Route path="allBatches" element={<AllBatches />} /> {/* ✅ Added Route */}
         <Route path="whatsapp" element={<WhatsAppAdminPage />} />
-         <Route path="allExams" element={<AllExams />} />
-         <Route path="fees" element={<Fees />} />
+        <Route path="allExams" element={<AllExams />} />
+        <Route path="fees" element={<Fees />} />
+        <Route path="tools" element={<ToolsPanel />} />
       </Route>
 
       {/* 🧭 Fallback */}

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,15 +1,25 @@
 import { useBranding } from '../context/BrandingContext';
 
 const Header = () => {
-  const branding = useBranding();
+  const { branding } = useBranding();
 
   return (
     <header className="p-4 shadow" style={{ backgroundColor: branding?.theme?.color }}>
-      <div className="flex items-center gap-4">
-        <img src={branding?.logo || '/default-logo.png'} alt="Logo" className="h-10" />
-        <h1 className="text-white text-xl font-semibold">
-          {branding?.institute || 'Instify Platform'}
-        </h1>
+      <div className="flex flex-col sm:flex-row items-center gap-4">
+        <img
+          src={branding?.logo || '/pwa-512x512.png'}
+          alt="Logo"
+          onError={(e) => (e.target.src = '/pwa-512x512.png')}
+          className="h-10"
+        />
+        <div>
+          <h1 className="text-white text-xl font-semibold">
+            {branding?.institute || 'Instify Platform'}
+          </h1>
+          {branding?.tagline && (
+            <p className="text-white text-sm opacity-80">{branding.tagline}</p>
+          )}
+        </div>
       </div>
     </header>
   );

--- a/src/components/Login.jsx
+++ b/src/components/Login.jsx
@@ -81,12 +81,20 @@ const Login = () => {
     <div className="min-h-screen flex flex-col items-center justify-center bg-white px-4">
       <Toaster position="top-center" />
       <div className="bg-white w-full max-w-md rounded-lg shadow p-6">
-        <div className="flex justify-center mb-6">
-          <img src={branding?.logo || '/logo.png'} alt="Logo" className="w-20 h-20 object-contain" />
+        <div className="flex justify-center mb-2">
+          <img
+            src={branding?.logo || '/pwa-512x512.png'}
+            alt="Logo"
+            onError={(e) => (e.target.src = '/pwa-512x512.png')}
+            className="w-20 h-20 object-contain"
+          />
         </div>
-        <h2 className="text-2xl font-bold text-center mb-6" style={{ color: branding?.theme?.color || '#5b5b5b' }}>
+        <h2 className="text-2xl font-bold text-center mb-1" style={{ color: branding?.theme?.color || '#5b5b5b' }}>
           {branding?.institute || 'Login'}
         </h2>
+        {branding?.tagline && (
+          <p className="text-center text-sm text-gray-600 mb-4">{branding.tagline}</p>
+        )}
         <div className="text-xs text-center mb-2 text-gray-500">
           (Login using your Center Code as both username and password)
         </div>

--- a/src/components/Login.jsx
+++ b/src/components/Login.jsx
@@ -30,6 +30,14 @@ const Login = () => {
     }
   }, [navigate, branding]);
 
+  // fetch branding on first load so login page shows correct logo/tagline
+  useEffect(() => {
+    if (!branding) {
+      const insti = getInstituteId(searchParams);
+      fetchBranding(insti, setBranding);
+    }
+  }, [searchParams, branding]);
+
   const handleLogin = async (e) => {
     e.preventDefault();
     setLoading(true);

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react';
 import MenuIcon from '@mui/icons-material/Menu';
 import AccountCircleIcon from '@mui/icons-material/AccountCircle';
 import { useApp } from '../context/AppContext';
+import { useBranding } from '../context/BrandingContext';
 import { useNavigate } from 'react-router-dom';
 import logoutUser from '../utils/logout';
 import { FaHeart } from "react-icons/fa";
@@ -12,6 +13,7 @@ import RightDrawer from './navbar/RightDrawer';
 
 export default function Navbar({ toggleSidebar }) {
   const { user, institute, loading } = useApp();
+  const { branding } = useBranding();
   const [showUserMenu, setShowUserMenu] = useState(false);
   const [isOpen, setIsOpen] = useState(false);
   const [showMasterItems, setShowMasterItems] = useState(false);
@@ -112,12 +114,17 @@ useEffect(() => {
           <button className="md:hidden" onClick={toggleSidebar}>
             {/* sidebar icon here if needed */}
           </button>
-          <button
-            onClick={() => navigate('/dashboard')}
-            className="font-bold text-lg text-blue-600 hover:underline focus:outline-none"
-          >
-            {instituteTitle}
-          </button>
+          <div className="leading-tight">
+            <button
+              onClick={() => navigate('/dashboard')}
+              className="font-bold text-lg text-blue-600 hover:underline focus:outline-none"
+            >
+              {instituteTitle}
+            </button>
+            {branding?.tagline && (
+              <div className="text-xs text-gray-500">{branding.tagline}</div>
+            )}
+          </div>
         </div>
 
         <div className="flex items-center pr-3 gap-4 relative">

--- a/src/components/Register.jsx
+++ b/src/components/Register.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import { useBranding } from '../context/BrandingContext';
 import axios from 'axios';
 import { useNavigate } from 'react-router-dom';
 import toast, { Toaster } from 'react-hot-toast';
@@ -6,6 +7,7 @@ import BASE_URL from '../config';
 
 const Signup = () => {
   const navigate = useNavigate();
+  const { branding } = useBranding();
 
   const [form, setForm] = useState({
     institute_title: '',
@@ -141,11 +143,19 @@ const Signup = () => {
     <div className="min-h-screen flex flex-col items-center justify-center px-4" style={{ backgroundColor: themeColor }}>
       <Toaster position="top-center" />
       <div className="bg-white w-full max-w-md rounded-lg shadow p-6">
-        <div className="flex justify-center mb-6">
-          <img src="/logo.png" alt="Logo" className="w-20 h-20 object-contain" />
+        <div className="flex justify-center mb-2">
+          <img
+            src="/pwa-512x512.png"
+            alt="Logo"
+            onError={(e) => (e.target.src = '/pwa-512x512.png')}
+            className="w-20 h-20 object-contain"
+          />
         </div>
 
-        <h2 className="text-2xl font-bold text-center text-theme mb-6">Register Institute</h2>
+        <h2 className="text-2xl font-bold text-center text-theme mb-1">Register Institute</h2>
+        {branding?.tagline && (
+          <p className="text-center text-sm text-gray-600 mb-4">{branding.tagline}</p>
+        )}
 
         <form onSubmit={otpSent ? handleSignup : handleSendOtp} className="space-y-4">
           <input type="text" value={form.institute_title} onChange={handleChange('institute_title')} placeholder="Institute Name" className="w-full px-3 py-2 border rounded-md shadow-sm" style={{ boxShadow: `0 0 0 1.5px ${themeColor}` }} required />

--- a/src/components/Signup.jsx
+++ b/src/components/Signup.jsx
@@ -1,5 +1,6 @@
 // src/pages/Signup.jsx
 import React, { useState, useEffect } from 'react';
+import { useBranding } from '../context/BrandingContext';
 import axios from 'axios';
 import { useNavigate } from 'react-router-dom';
 import toast, { Toaster } from 'react-hot-toast';
@@ -8,6 +9,7 @@ import { storeUserData, storeInstituteData } from '../utils/storageUtils';
 
 const Signup = () => {
   const navigate = useNavigate();
+  const { branding } = useBranding();
   const [form, setForm] = useState({
     institute_title: '',
     institute_type: '',
@@ -195,10 +197,16 @@ const Signup = () => {
     <div className="min-h-screen flex flex-col items-center justify-center px-4" style={{ backgroundColor: themeColor }}>
       <Toaster position="top-center" />
       <div className="bg-white w-full max-w-md rounded-lg shadow p-6">
-        <div className="flex justify-center mb-6">
-          <img src="/logo.png" alt="Logo" className="w-20 h-20 object-contain" />
+        <div className="flex justify-center mb-2">
+          <img
+            src="/pwa-512x512.png"
+            alt="Logo"
+            onError={(e) => (e.target.src = '/pwa-512x512.png')}
+            className="w-20 h-20 object-contain"
+          />
         </div>
-        <h2 className="text-2xl font-bold text-center text-theme mb-6">Register Institute</h2>
+        <h2 className="text-2xl font-bold text-center text-theme mb-1">Register Institute</h2>
+        <p className="text-center text-sm text-gray-600 mb-4">{branding?.tagline}</p>
         <form onSubmit={otpSent ? handleSignup : handleSendOtp} className="space-y-4">
           <input
             type="text"

--- a/src/components/admissions/AdmissionPaymentInstallmentTab.jsx
+++ b/src/components/admissions/AdmissionPaymentInstallmentTab.jsx
@@ -62,7 +62,7 @@ const AdmissionPaymentInstallmentTab = ({ form, handleChange, installmentPlan, p
           {installmentPlan.map(p => (
             <tr key={p.installmentNo}>
               <td className="border px-2 py-1 text-center truncate">{p.installmentNo}</td>
-              <td className="border px-2 py-1 truncate">{p.dueDate}</td>
+              <td className="border px-2 py-1 truncate">{new Date(p.dueDate).toLocaleDateString()}</td>
               <td className="border px-2 py-1 text-right truncate">{p.amount}</td>
             </tr>
           ))}

--- a/src/components/admissions/ReceiptModal.jsx
+++ b/src/components/admissions/ReceiptModal.jsx
@@ -157,7 +157,7 @@ const ReceiptModal = ({ data, institute = {}, onPrint, onClose }) => {
           {fields.installmentPlan.map(p => (
             <tr key={p.installmentNo}>
               <td className="border px-2 py-1 text-center truncate">{p.installmentNo}</td>
-              <td className="border px-2 py-1 truncate">{p.dueDate}</td>
+              <td className="border px-2 py-1 truncate">{new Date(p.dueDate).toLocaleDateString()}</td>
               <td className="border px-2 py-1 text-right truncate">{p.amount}</td>
             </tr>
           ))}

--- a/src/components/navbar/RightDrawer.jsx
+++ b/src/components/navbar/RightDrawer.jsx
@@ -107,6 +107,18 @@ const RightDrawer = ({
                     <EventNoteIcon fontSize="small" />
                     Institutes
                   </div>
+                  {user?.role === 'super_admin' && (
+                    <div
+                      onClick={() => {
+                        navigate('/dashboard/tools');
+                        onClose();
+                      }}
+                      className="flex items-center gap-2 px-3 py-2 rounded hover:bg-gray-100 text-sm cursor-pointer"
+                    >
+                      <EventNoteIcon fontSize="small" />
+                      Tools
+                    </div>
+                  )}
                 </>
               )}
             </div>

--- a/src/components/reports/LeadDetailsModal.jsx
+++ b/src/components/reports/LeadDetailsModal.jsx
@@ -109,7 +109,7 @@ const LeadDetailsModal = ({
                 {(receiptInfo.installmentPlan || []).map((p) => (
                   <tr key={p.installmentNo}>
                     <td className="border px-2 py-1 text-center truncate">{p.installmentNo}</td>
-                    <td className="border px-2 py-1 truncate">{p.dueDate}</td>
+                    <td className="border px-2 py-1 truncate">{new Date(p.dueDate).toLocaleDateString()}</td>
                     <td className="border px-2 py-1 text-right truncate">{p.amount}</td>
                   </tr>
                 ))}

--- a/src/context/BrandingContext.jsx
+++ b/src/context/BrandingContext.jsx
@@ -5,10 +5,11 @@ import BASE_URL from '../config';
 export const BrandingContext = createContext();
 
 const defaultTheme = {
-  color: '#5b5b5b', // fallback green
-  logo: '/logo.png',
-  favicon: '/favicon.ico',
-  institute: 'Instify'
+  color: '#5b5b5b', // fallback theme color
+  logo: '/pwa-512x512.png',
+  favicon: '/icon.svg',
+  institute: 'Instify',
+  tagline: 'Manage your institute with ease'
 };
 
 function hexToRgb(hex) {
@@ -50,7 +51,8 @@ const BrandingProvider = ({ children }) => {
           institute: data.institute || defaultTheme.institute,
           color: data.theme?.color || defaultTheme.color,
           logo: data.logo || defaultTheme.logo,
-          favicon: data.favicon || defaultTheme.favicon
+          favicon: data.favicon || defaultTheme.favicon,
+          tagline: data.tagline || defaultTheme.tagline,
         };
 
         setBranding(final);
@@ -65,7 +67,7 @@ const BrandingProvider = ({ children }) => {
           link.rel = 'icon';
           document.head.appendChild(link);
         }
-        link.href = final.favicon || '/favicon.ico';
+        link.href = final.favicon || '/icon.svg';
 
         document.title = `${final.institute} | Instify`;
       } catch (err) {
@@ -88,3 +90,5 @@ const BrandingProvider = ({ children }) => {
 };
 
 export default BrandingProvider;
+
+export const useBranding = () => React.useContext(BrandingContext);

--- a/src/pages/AddAttendance.jsx
+++ b/src/pages/AddAttendance.jsx
@@ -197,9 +197,9 @@ export default function AddAttendance() {
         <div className="bg-[#e5ddd5] pt-5 max-w-8xl mx-auto px-2">
             <div className="shadow-lg overflow-hidden">
                 <div className="flex flex-col md:flex-row md:items-end md:justify-between gap-4 p-2">
-                    <div className="bg-white overflow-x-auto w-full md:w-3/4">
+                    <div className="bg-white overflow-x-auto max-h-[70vh] w-full md:w-3/4">
                         <table className="min-w-full text-sm text-center border">
-                            <thead className="bg-gray-100">
+                            <thead className="bg-gray-100 sticky top-0">
                                 <tr>
                                     <th className="px-4 py-2 border">In</th>
                                     <th className="px-4 py-2 border hidden md:table-cell">Lunch</th>

--- a/src/pages/CoursesCategory.jsx
+++ b/src/pages/CoursesCategory.jsx
@@ -100,9 +100,9 @@ const CoursesCategory = () => {
         </div>
       </div>
 
-      <div className="overflow-x-auto">
+      <div className="overflow-x-auto max-h-[70vh]">
       <table className="min-w-full border">
-        <thead className="bg-gray-100">
+        <thead className="bg-gray-100 sticky top-0">
           <tr>
             <th className="p-2 border">Name</th>
             <th className="p-2 border">Action</th>

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -33,6 +33,14 @@ const Dashboard = () => {
   const [expired, setExpired] = useState(false);
   const [daysLeft, setDaysLeft] = useState(null);
 
+  useEffect(() => {
+    if (expiryDateStr) {
+      const diff = Math.ceil((new Date(expiryDateStr) - new Date()) / (1000 * 60 * 60 * 24));
+      setDaysLeft(diff);
+      if (diff < 0) setExpired(true);
+    }
+  }, [expiryDateStr]);
+
  useEffect(() => {
   const institute_uuid = localStorage.getItem('institute_uuid');
   const fetchUrl = `${API_URL}?institute_uuid=${institute_uuid}`;
@@ -104,9 +112,9 @@ const Dashboard = () => {
         {/* Institute name on top */}
         
         {/* Days left on trial */}
-        {planType === 'trial' && daysLeft !== null && (
-          <div className="text-center text-orange-500 mb-2">
-            {daysLeft} day{daysLeft !== 1 && 's'} left in your free trial
+        {planType === 'trial' && daysLeft !== null && daysLeft >= 0 && (
+          <div className="bg-orange-100 text-orange-700 text-sm text-center py-2 mb-2">
+            Trial expires in {daysLeft} day{daysLeft !== 1 && 's'}!
           </div>
         )}
         {/* Attendance Board */}

--- a/src/pages/Delete.jsx
+++ b/src/pages/Delete.jsx
@@ -607,9 +607,9 @@ import { getThemeColor } from '../utils/storageUtils';
                 />
                 <input placeholder="EMI" value={form.emi} type="number" className="border p-2" readOnly />
                   {installmentPlan.length > 0 && (
-                  <div className="overflow-x-auto">
+                  <div className="overflow-x-auto max-h-[60vh]">
                   <table className="min-w-full border mt-2 text-sm">
-                    <thead>
+                    <thead className="sticky top-0 bg-gray-100">
                       <tr className="bg-gray-100">
                         <th className="border px-2 py-1">#</th>
                         <th className="border px-2 py-1">Due Date</th>
@@ -620,7 +620,7 @@ import { getThemeColor } from '../utils/storageUtils';
                       {installmentPlan.map(p => (
                         <tr key={p.installmentNo}>
                           <td className="border px-2 py-1 text-center truncate">{p.installmentNo}</td>
-                          <td className="border px-2 py-1 truncate">{p.dueDate}</td>
+                          <td className="border px-2 py-1 truncate">{new Date(p.dueDate).toLocaleDateString()}</td>
                           <td className="border px-2 py-1 text-right truncate">{p.amount}</td>
                         </tr>
                       ))}

--- a/src/pages/Fees.jsx
+++ b/src/pages/Fees.jsx
@@ -46,9 +46,9 @@ const Fees = () => {
       ) : fees.length === 0 ? (
         <p>No fee collections today.</p>
       ) : (
-        <div className="overflow-auto">
+        <div className="overflow-auto max-h-[70vh]">
           <table className="min-w-full table-auto border border-gray-300">
-            <thead>
+            <thead className="sticky top-0 bg-gray-100">
               <tr className="bg-gray-100">
                 <th className="border px-4 py-2">Student Name</th>
                 <th className="border px-4 py-2">Admission ID</th>
@@ -62,7 +62,7 @@ const Fees = () => {
                   <tr key={`${idx}-${i}`} className="hover:bg-gray-50">
                     <td className="border px-4 py-2">{fee.studentName}</td>
                     <td className="border px-4 py-2">{fee.admissionId}</td>
-                    <td className="border px-4 py-2">{plan.dueDate}</td>
+                    <td className="border px-4 py-2">{new Date(plan.dueDate).toLocaleDateString()}</td>
                     <td className="border px-4 py-2">₹{plan.amount}</td>
                   </tr>
                 ))

--- a/src/pages/Institutes.jsx
+++ b/src/pages/Institutes.jsx
@@ -54,9 +54,9 @@ const Institutes = () => {
     <div className="min-h-screen p-6" style={{ backgroundColor: themeColor }}>
       <Toaster position="top-right" />
       <h1 className="text-3xl font-bold text-gray-800 mb-4">Manage Institutes</h1>
-      <div className="overflow-x-auto">
+      <div className="overflow-x-auto max-h-[70vh]">
         <table className="min-w-full border border-gray-300 rounded-md">
-          <thead>
+          <thead className="sticky top-0 bg-gray-200">
             <tr className="bg-gray-200 text-center text-sm">
               <th className="p-2 border">Name</th>
               <th className="p-2 border hidden md:table-cell">Center Code</th>

--- a/src/pages/OrgCategories.jsx
+++ b/src/pages/OrgCategories.jsx
@@ -105,9 +105,9 @@ const OrgCategories = () => {
         </button>
       </div>
 
-      <div className="overflow-x-auto">
+      <div className="overflow-x-auto max-h-[70vh]">
       <table className="min-w-full border">
-        <thead className="bg-gray-100">
+        <thead className="bg-gray-100 sticky top-0">
           <tr>
             <th className="p-2 border">Category</th>
             <th className="p-2 border hidden md:table-cell">Description</th>

--- a/src/pages/Owner.jsx
+++ b/src/pages/Owner.jsx
@@ -134,9 +134,9 @@ center_head_name: '',
         </button>
       </div>
 
-      <div className="overflow-x-auto">
+      <div className="overflow-x-auto max-h-[70vh]">
       <table className="min-w-full border border-gray-300 rounded-md">
-        <thead>
+        <thead className="sticky top-0 bg-gray-200">
           <tr className="bg-gray-200 text-center">
             <th className="p-2 border">Name</th>
             <th className="p-2 border hidden md:table-cell">Mobile</th>

--- a/src/pages/PaymentMode.jsx
+++ b/src/pages/PaymentMode.jsx
@@ -103,9 +103,9 @@ const PaymentMode = () => {
         </button>
       </div>
 
-      <div className="overflow-x-auto">
+      <div className="overflow-x-auto max-h-[70vh]">
       <table className="min-w-full border">
-        <thead className="bg-gray-100">
+        <thead className="bg-gray-100 sticky top-0">
           <tr>
             
             <th className="p-2 border">Mode</th>

--- a/src/pages/ToolsPanel.jsx
+++ b/src/pages/ToolsPanel.jsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { useApp } from '../context/AppContext';
+import { useNavigate } from 'react-router-dom';
+
+const ToolsPanel = () => {
+  const { user } = useApp();
+  const navigate = useNavigate();
+
+  if (!user || user.role !== 'super_admin') {
+    return (
+      <div className="p-6">
+        <h2 className="text-xl font-semibold text-red-600">Access Denied</h2>
+      </div>
+    );
+  }
+
+  return (
+    <div className="p-6 space-y-4">
+      <h1 className="text-2xl font-bold">Superadmin Tools</h1>
+      <p className="text-gray-600">Future tools will appear here.</p>
+      <button onClick={() => navigate(-1)} className="text-blue-600 underline">
+        Go Back
+      </button>
+    </div>
+  );
+};
+
+export default ToolsPanel;

--- a/src/pages/WhatsAppAdminPage.jsx
+++ b/src/pages/WhatsAppAdminPage.jsx
@@ -10,6 +10,8 @@ const WhatsAppAdminPage = () => {
     const [loading, setLoading] = useState(false);
     const [phone, setPhone] = useState('');
     const [message, setMessage] = useState('');
+    const [bulkNumbers, setBulkNumbers] = useState('');
+    const [scheduleTime, setScheduleTime] = useState('');
 
     const branding = JSON.parse(localStorage.getItem('branding'));
     const institute_uuid = branding?.uuid;
@@ -89,6 +91,27 @@ const WhatsAppAdminPage = () => {
         }
     };
 
+    const scheduleBulkMessage = async () => {
+        if (!bulkNumbers || !message || !scheduleTime) return toast.error('All fields required');
+        if (!institute_uuid) return toast.error('Institute UUID not found.');
+        try {
+            const numbers = bulkNumbers.split(',').map(n => n.trim()).filter(Boolean);
+            await axios.post(`${BASE_URL}/api/whatsapp/schedule`, {
+                numbers,
+                message,
+                schedule: scheduleTime,
+                institute_uuid
+            });
+            toast.success('Bulk message scheduled');
+            setBulkNumbers('');
+            setScheduleTime('');
+            setMessage('');
+        } catch (error) {
+            console.error(error);
+            toast.error('Failed to schedule');
+        }
+    };
+
     return (
         <div className="max-w-md mx-auto p-4 space-y-4">
             <h1 className="text-2xl font-bold">📲 WhatsApp Admin Panel</h1>
@@ -131,6 +154,34 @@ const WhatsAppAdminPage = () => {
                     className="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700 w-full"
                 >
                     Send Message
+                </button>
+            </div>
+
+            <div className="space-y-2 border-t pt-4 mt-6">
+                <h2 className="text-lg font-semibold">Schedule/Bulk Send</h2>
+                <textarea
+                    placeholder="Comma separated numbers"
+                    value={bulkNumbers}
+                    onChange={e => setBulkNumbers(e.target.value)}
+                    className="border w-full p-2 rounded"
+                />
+                <input
+                    type="datetime-local"
+                    value={scheduleTime}
+                    onChange={e => setScheduleTime(e.target.value)}
+                    className="border w-full p-2 rounded"
+                />
+                <textarea
+                    placeholder="Message"
+                    value={message}
+                    onChange={e => setMessage(e.target.value)}
+                    className="border w-full p-2 rounded"
+                />
+                <button
+                    onClick={scheduleBulkMessage}
+                    className="bg-purple-600 text-white px-4 py-2 rounded hover:bg-purple-700 w-full"
+                >
+                    Schedule Bulk Message
                 </button>
             </div>
         </div>

--- a/src/pages/instituteProfile.jsx
+++ b/src/pages/instituteProfile.jsx
@@ -108,7 +108,7 @@ const InstituteProfile = () => {
         link.rel = 'icon';
         document.head.appendChild(link);
       }
-      link.href = updated.theme_favicon || '/favicon.ico';
+      link.href = updated.theme_favicon || '/icon.svg';
 
       localStorage.setItem('institute_title', updated.institute_title);
       localStorage.setItem('theme_color', updated.theme_color);

--- a/src/utils/brandingUtils.js
+++ b/src/utils/brandingUtils.js
@@ -24,7 +24,7 @@ export const fetchBranding = async (insti, setBranding) => {
       if (link) document.head.removeChild(link);
       link = document.createElement('link');
       link.rel = 'icon';
-      link.href = iconUrl || '/favicon.ico';
+      link.href = iconUrl || '/icon.svg';
       document.head.appendChild(link);
     };
     updateFavicon(data.favicon);


### PR DESCRIPTION
## Summary
- show branding tagline on login and navbar
- update default favicon and logo fallback
- compute trial expiry warning in dashboard
- make table headers sticky and format dates
- extend WhatsApp page with bulk scheduling
- add superadmin Tools panel and menu item

## Testing
- `npm run build` *(fails: 403 Forbidden - registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_6873b23ea7d08322a017107cd3866f8d