### PR TITLE
Fix layout padding for fixed header/footer

### DIFF
--- a/src/components/admissions/AdmissionFormModal.jsx
+++ b/src/components/admissions/AdmissionFormModal.jsx
@@ -92,9 +92,9 @@ const handleNext = async () => {
   const handleBack = () => setTab(tab - 1);
 
   return (
-    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center p-4 overflow-y-auto z-[60]">
       <Toaster />
-      <div className="bg-white rounded-lg shadow-lg w-full max-w-xl max-h-[90vh] overflow-y-auto">
+      <div className="bg-white rounded-lg shadow-lg w-full max-w-xl max-h-screen overflow-y-auto">
         <div className="flex justify-between items-center p-4 border-b">
           <h2 className="text-lg font-bold" style={{ color: themeColor }}>
             {editingId ? 'Edit Admission' : 'Add New Admission'}

--- a/src/components/admissions/CertificateModel.jsx
+++ b/src/components/admissions/CertificateModel.jsx
@@ -11,7 +11,7 @@ const CertificateModal = ({ certificate, onClose }) => {
 
   
   return (
-    <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-50 z-50">
+    <div className="fixed inset-0 flex items-center justify-center p-4 overflow-y-auto bg-black bg-opacity-50 z-[60]">
       <div className="bg-white rounded shadow-lg p-6 w-full max-w-sm">
         <h2 className="text-lg font-semibold mb-4">Certificate</h2>
         <div className="mb-4">

--- a/src/components/admissions/ConfirmAdmissionModal.jsx
+++ b/src/components/admissions/ConfirmAdmissionModal.jsx
@@ -56,7 +56,7 @@ const ConfirmAdmissionModal = ({ admission, onClose, onUpdated }) => {
   return (
     <>
       <div
-        className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-40 z-50"
+        className="fixed inset-0 flex items-center justify-center p-4 overflow-y-auto bg-black bg-opacity-40 z-[60]"
         onMouseDown={handleBackdrop}
       >
         <div
@@ -133,7 +133,7 @@ const ConfirmAdmissionModal = ({ admission, onClose, onUpdated }) => {
 export default ConfirmAdmissionModal;
 
 const ConfirmedAdmissionPopup = ({ onClose }) => (
-  <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+  <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center p-4 overflow-y-auto z-[60]">
     <div className="bg-white p-6 rounded shadow max-w-sm w-full">
       <h2 className="text-xl font-bold mb-4">Confirmed Admission Details</h2>
       

--- a/src/components/admissions/DeleteEnquiry.jsx
+++ b/src/components/admissions/DeleteEnquiry.jsx
@@ -77,7 +77,7 @@ const EnquiryFormModal = ({ onClose }) => {
   };
 
   return (
-    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center p-4 overflow-y-auto z-[60]">
       <Toaster />
       <div className="bg-white rounded p-4 w-full max-w-lg shadow">
         <h2 className="text-lg font-bold mb-4">Add Enquiry</h2>

--- a/src/components/admissions/ReceiptModal.jsx
+++ b/src/components/admissions/ReceiptModal.jsx
@@ -62,7 +62,7 @@ const ReceiptModal = ({ data, institute = {}, onPrint, onClose }) => {
   };
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50 print:bg-white">
+    <div className="fixed inset-0 z-[60] flex items-center justify-center p-4 overflow-y-auto bg-black bg-opacity-50 print:bg-white">
       {/* Inject CSS for print */}
       <style>{style}</style>
       <div

--- a/src/components/common/ManageBatchModal.jsx
+++ b/src/components/common/ManageBatchModal.jsx
@@ -71,7 +71,7 @@ useEffect(() => {
 
   return (
     <div
-      className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-40 z-50"
+      className="fixed inset-0 flex items-center justify-center p-4 overflow-y-auto bg-black bg-opacity-40 z-[60]"
       onMouseDown={handleBackdrop}
       aria-modal="true"
       role="dialog"

--- a/src/components/common/ManageExamModal.jsx
+++ b/src/components/common/ManageExamModal.jsx
@@ -53,7 +53,7 @@ const ManageExamModal = ({ admission, onClose, onUpdated }) => {
 
   return (
     <div
-      className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-40 z-50"
+      className="fixed inset-0 flex items-center justify-center p-4 overflow-y-auto bg-black bg-opacity-40 z-[60]"
       onMouseDown={handleBackdrop}
       aria-modal="true"
       role="dialog"

--- a/src/components/common/Modal.jsx
+++ b/src/components/common/Modal.jsx
@@ -6,11 +6,11 @@ import React from 'react';
  */
 const Modal = ({ title, onClose, actions, children }) => (
   <div
-    className="fixed inset-0 bg-black bg-opacity-40 flex items-center justify-center z-50"
+    className="fixed inset-0 z-[60] bg-black bg-opacity-40 flex items-center justify-center p-4 overflow-y-auto"
     onClick={onClose}
   >
     <div
-      className="bg-white p-6 rounded shadow max-w-xl w-full max-h-[90vh] overflow-y-auto"
+      className="bg-white p-6 rounded shadow max-w-xl w-full max-h-screen overflow-y-auto"
       onClick={(e) => e.stopPropagation()}
     >
       {title && <h2 className="text-xl font-semibold mb-4">{title}</h2>}

--- a/src/components/leads/LeadEditModal.jsx
+++ b/src/components/leads/LeadEditModal.jsx
@@ -32,7 +32,7 @@ const LeadEditModal = ({ lead, courses, onClose, onSuccess }) => {
   };
 
   return (
-    <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-50 z-50">
+    <div className="fixed inset-0 flex items-center justify-center p-4 overflow-y-auto bg-black bg-opacity-50 z-[60]">
       <div className="bg-white rounded shadow-lg p-6 w-full max-w-lg">
         <h2 className="text-lg font-semibold mb-4">Edit Lead Details</h2>
         <form onSubmit={handleSubmit} className="space-y-4">

--- a/src/components/leads/LeadFormModal.jsx
+++ b/src/components/leads/LeadFormModal.jsx
@@ -97,7 +97,7 @@ const LeadFormModal = ({ onClose, onSuccess, institute_uuid }) => {
   };
 
   return (
-    <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-50 z-50">
+    <div className="fixed inset-0 flex items-center justify-center p-4 overflow-y-auto bg-black bg-opacity-50 z-[60]">
       <Toaster />
       <div className="bg-white rounded shadow-lg p-6 w-full max-w-lg relative">
         {/* X close button in top right */}

--- a/src/components/leads/LeadStatusModal.jsx
+++ b/src/components/leads/LeadStatusModal.jsx
@@ -60,7 +60,7 @@ const LeadStatusModal = ({ lead, onClose, refresh }) => {
   };
 
   return (
-    <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-50 z-50">
+    <div className="fixed inset-0 flex items-center justify-center p-4 overflow-y-auto bg-black bg-opacity-50 z-[60]">
       <div className="bg-white rounded shadow-lg p-6 w-full max-w-sm">
         <h2 className="text-lg font-semibold mb-4">Update Lead Status</h2>
         <div className="mb-4">

--- a/src/components/reports/LeadDetailsModal.jsx
+++ b/src/components/reports/LeadDetailsModal.jsx
@@ -15,8 +15,8 @@ const LeadDetailsModal = ({
   if (!lead) return null;
 
   return (
-    <div className="fixed inset-0 bg-black bg-opacity-40 flex items-center justify-center z-50">
-      <div className="bg-white rounded-lg shadow-lg w-full max-w-md mx-2 my-4 p-3 sm:p-6 overflow-y-auto max-h-[95vh]">
+    <div className="fixed inset-0 bg-black bg-opacity-40 flex items-center justify-center p-4 overflow-y-auto z-[60]">
+      <div className="bg-white rounded-lg shadow-lg w-full max-w-md mx-2 my-4 p-3 sm:p-6 overflow-y-auto max-h-screen">
         {/* Header: Name */}
         <div className="flex flex-col items-start mb-2">
           <h2 className="text-xl font-bold text-gray-900">

--- a/src/layouts/DashboardLayout.jsx
+++ b/src/layouts/DashboardLayout.jsx
@@ -33,7 +33,13 @@ export default function DashboardLayout() {
       <div className="flex-1 flex flex-col">
         <Navbar toggleSidebar={toggleSidebar} />
         <div className="flex flex-1 min-h-0">
-          <main className="flex-1 p-4 overflow-y-auto">
+          {/*
+            The navbar and footer use fixed positioning which can cause
+            page content to be hidden behind them. Add top and bottom
+            padding to the main section so the content is fully
+            visible and scrollable.
+          */}
+          <main className="flex-1 p-4 pt-20 pb-24 overflow-y-auto">
             <Outlet />
           </main>
 

--- a/src/pages/Batches.jsx
+++ b/src/pages/Batches.jsx
@@ -158,7 +158,7 @@ const Batches = () => {
       )}
 
       {showModal && (
-        <div className="fixed inset-0 bg-black bg-opacity-40 flex items-center justify-center z-50">
+        <div className="fixed inset-0 bg-black bg-opacity-40 flex items-center justify-center p-4 overflow-y-auto z-[60]">
           <div className="bg-white p-6 rounded-xl w-full max-w-md shadow-lg">
             <h2 className="text-xl font-semibold mb-4">
               {editingId ? 'Edit Batch' : 'Add New Batch'}

--- a/src/pages/Courses.jsx
+++ b/src/pages/Courses.jsx
@@ -187,7 +187,7 @@ const Courses = () => {
 
       {/* Modal */}
       {showModal && (
-        <div className="fixed inset-0 bg-black bg-opacity-40 flex items-center justify-center z-50">
+        <div className="fixed inset-0 bg-black bg-opacity-40 flex items-center justify-center p-4 overflow-y-auto z-[60]">
           <div className="bg-white p-6 rounded-xl w-full max-w-md shadow-lg">
             <h2 className="text-xl font-semibold mb-4">{editingId ? 'Edit Course' : 'Add New Course'}</h2>
             <form onSubmit={handleSubmit} className="grid grid-cols-1 gap-4">

--- a/src/pages/CoursesCategory.jsx
+++ b/src/pages/CoursesCategory.jsx
@@ -128,8 +128,8 @@ const CoursesCategory = () => {
 
       {/* Modal */}
       {showModal && (
-        <div className="fixed inset-0 bg-black bg-opacity-40 flex items-center justify-center z-50">
-          <div className="bg-white p-6 rounded w-full max-w-md max-h-[90vh] overflow-y-auto shadow">
+        <div className="fixed inset-0 bg-black bg-opacity-40 flex items-center justify-center p-4 overflow-y-auto z-[60]">
+          <div className="bg-white p-6 rounded w-full max-w-md max-h-screen overflow-y-auto shadow">
             <h2 className="text-xl font-semibold mb-4">{editingId ? 'Edit Course' : 'Add New Course Category'}</h2>
             <form onSubmit={handleSubmit} className="grid grid-cols-1 gap-4">
               <input type="text" value={form.name} onChange={handleChange('name')} className="border p-2 w-full" placeholder="Category Name" required />

--- a/src/pages/Delete.jsx
+++ b/src/pages/Delete.jsx
@@ -483,9 +483,9 @@ import { getThemeColor } from '../utils/storageUtils';
     });
 
     return (
-      <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+      <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center p-4 overflow-y-auto z-[60]">
         <Toaster />
-        <div className="bg-white rounded-lg shadow-lg w-full max-w-xl max-h-[90vh] overflow-y-auto">
+        <div className="bg-white rounded-lg shadow-lg w-full max-w-xl max-h-screen overflow-y-auto">
           <div className="flex justify-between items-center p-4 border-b">
             <h2 className="text-lg font-bold" style={{ color: themeColor }}>
               {editingId ? 'Edit Admission' : 'Add New Admission'}

--- a/src/pages/Education.jsx
+++ b/src/pages/Education.jsx
@@ -162,7 +162,7 @@ const Education = () => {
       )}
 
       {showModal && (
-        <div className="fixed inset-0 bg-black bg-opacity-40 flex items-center justify-center z-50">
+        <div className="fixed inset-0 bg-black bg-opacity-40 flex items-center justify-center p-4 overflow-y-auto z-[60]">
           <div className="bg-white p-6 rounded-xl w-full max-w-md shadow-lg">
             <h2 className="text-xl font-semibold mb-4">
               {editingId ? 'Edit Education' : 'Add New Education'}

--- a/src/pages/Enquiry.jsx
+++ b/src/pages/Enquiry.jsx
@@ -170,7 +170,7 @@ const Enquiry = () => {
 
       {/* Add/Edit Modal */}
       {showModal && (
-        <div className="fixed inset-0 bg-black bg-opacity-40 flex items-center justify-center z-50">
+        <div className="fixed inset-0 bg-black bg-opacity-40 flex items-center justify-center p-4 overflow-y-auto z-[60]">
           <div className="bg-white p-6 rounded max-w-sm w-full">
             <h2 className="text-lg font-bold mb-4">{isEditMode ? 'Edit Enquiry' : 'Add Enquiry'}</h2>
             <form onSubmit={handleSubmit} className="flex flex-col gap-3">
@@ -226,7 +226,7 @@ const Enquiry = () => {
 
       {/* Follow-Up Modal */}
       {showFollowUpModal && (
-        <div className="fixed inset-0 bg-black bg-opacity-40 flex items-center justify-center z-50">
+        <div className="fixed inset-0 bg-black bg-opacity-40 flex items-center justify-center p-4 overflow-y-auto z-[60]">
           <div className="bg-white p-6 rounded max-w-sm w-full">
             <h2 className="text-lg font-bold mb-4">Add Follow-Up</h2>
             <form onSubmit={handleFollowUpSubmit} className="flex flex-col gap-3">
@@ -266,7 +266,7 @@ const Enquiry = () => {
 
       {/* Action Modal */}
       {actionModal && (
-        <div className="fixed inset-0 bg-black bg-opacity-40 flex items-center justify-center z-50">
+        <div className="fixed inset-0 bg-black bg-opacity-40 flex items-center justify-center p-4 overflow-y-auto z-[60]">
           <div className="bg-white p-6 rounded max-w-sm w-full">
             <h2 className="text-lg font-bold mb-4">
               {actionModal.firstName} {actionModal.lastName}

--- a/src/pages/Exam.jsx
+++ b/src/pages/Exam.jsx
@@ -153,7 +153,7 @@ const Exam = () => {
       )}
 
       {showModal && (
-        <div className="fixed inset-0 bg-black bg-opacity-40 flex items-center justify-center z-50">
+        <div className="fixed inset-0 bg-black bg-opacity-40 flex items-center justify-center p-4 overflow-y-auto z-[60]">
           <div className="bg-white p-6 rounded-xl w-full max-w-md shadow-lg">
             <h2 className="text-xl font-semibold mb-4">
               {editingId ? 'Edit Exam' : 'Add New Exam'}

--- a/src/pages/Followup.jsx
+++ b/src/pages/Followup.jsx
@@ -266,7 +266,7 @@ const Followup = () => {
       </div>
 
       {showModal && (
-        <div className="fixed inset-0 bg-black bg-opacity-40 flex items-center justify-center z-50 overflow-y-auto">
+        <div className="fixed inset-0 bg-black bg-opacity-40 flex items-center justify-center p-4 overflow-y-auto z-[60] overflow-y-auto">
           <div className="bg-white p-6 rounded shadow w-full max-w-3xl mx-2">
             <h2 className="text-xl font-bold mb-4">{editingId ? 'Edit Enquiry' : 'Add Enquiry'}</h2>
             <form onSubmit={handleSubmit} className="flex flex-col gap-3">
@@ -309,8 +309,8 @@ const Followup = () => {
 
       {/* Admission Convert Modal */}
       {showAdmission && (
-        <div className="fixed inset-0 bg-black bg-opacity-40 flex items-center justify-center z-50">
-          <div className="bg-white p-6 rounded shadow max-w-xl w-full max-h-[90vh] overflow-y-auto">
+        <div className="fixed inset-0 bg-black bg-opacity-40 flex items-center justify-center p-4 overflow-y-auto z-[60]">
+          <div className="bg-white p-6 rounded shadow max-w-xl w-full max-h-screen overflow-y-auto">
             <h2 className="text-2xl font-bold mb-4 text-green-700">Convert to Admission</h2>
             <form onSubmit={submitAdmission} className="flex flex-col gap-3">
 
@@ -414,7 +414,7 @@ const Followup = () => {
 
       {/* Action Modal */}
       {actionModal && (
-        <div className="fixed inset-0 bg-black bg-opacity-40 flex items-center justify-center z-50">
+        <div className="fixed inset-0 bg-black bg-opacity-40 flex items-center justify-center p-4 overflow-y-auto z-[60]">
           <div className="bg-white p-6 rounded shadow w-full h-full overflow-y-auto">
             <h2 className="text-lg font-bold mb-4">
               {actionModal.firstName} {actionModal.lastName}

--- a/src/pages/Followup.jsx
+++ b/src/pages/Followup.jsx
@@ -265,9 +265,9 @@ const Followup = () => {
         ))}
       </div>
 
-      {showModal && (
-        <div className="fixed inset-0 bg-black bg-opacity-40 flex items-center justify-center p-4 overflow-y-auto z-[60] overflow-y-auto">
-          <div className="bg-white p-6 rounded shadow w-full max-w-3xl mx-2">
+        {showModal && (
+          <div className="fixed inset-0 bg-black bg-opacity-40 flex items-center justify-center p-4 overflow-y-auto z-[60]">
+            <div className="bg-white p-6 rounded shadow w-full max-w-3xl mx-2">
             <h2 className="text-xl font-bold mb-4">{editingId ? 'Edit Enquiry' : 'Add Enquiry'}</h2>
             <form onSubmit={handleSubmit} className="flex flex-col gap-3">
               <input value={form.firstName} onChange={handleChange('firstName')} placeholder="First Name" className="border p-2" />

--- a/src/pages/OrgCategories.jsx
+++ b/src/pages/OrgCategories.jsx
@@ -148,7 +148,7 @@ const OrgCategories = () => {
       </div>
 
       {showModal && (
-        <div className="fixed inset-0 bg-black bg-opacity-40 flex items-center justify-center z-50">
+        <div className="fixed inset-0 bg-black bg-opacity-40 flex items-center justify-center p-4 overflow-y-auto z-[60]">
           <div className="bg-white p-6 rounded w-full max-w-md">
             <h2 className="text-xl font-semibold mb-4">
               {editingId ? 'Edit Category' : 'Add New Category'}

--- a/src/pages/Owner.jsx
+++ b/src/pages/Owner.jsx
@@ -177,8 +177,8 @@ center_head_name: '',
       </div>
 
       {showModal && (
-        <div className="fixed inset-0 bg-black bg-opacity-40 flex items-center justify-center z-50">
-          <div className="bg-white p-6 rounded shadow max-w-xl w-full max-h-[90vh] overflow-y-auto">
+        <div className="fixed inset-0 bg-black bg-opacity-40 flex items-center justify-center p-4 overflow-y-auto z-[60]">
+          <div className="bg-white p-6 rounded shadow max-w-xl w-full max-h-screen overflow-y-auto">
             <h2 className="text-xl font-semibold mb-4">{editingId ? 'Edit institute' : 'Add New institute'}</h2>
             <form onSubmit={handleSubmit} className="space-y-3">
               <input type="text" value={form.institute_title} onChange={handleInputChange('institute_title')} className="w-full p-2 border rounded" placeholder="institute_title" required />

--- a/src/pages/PaymentMode.jsx
+++ b/src/pages/PaymentMode.jsx
@@ -147,7 +147,7 @@ const PaymentMode = () => {
 
       {/* Modal */}
       {showModal && (
-        <div className="fixed inset-0 bg-black bg-opacity-40 flex items-center justify-center z-50">
+        <div className="fixed inset-0 bg-black bg-opacity-40 flex items-center justify-center p-4 overflow-y-auto z-[60]">
           <div className="bg-white p-6 rounded w-full max-w-md">
             <h2 className="text-xl font-semibold mb-4">{editingId ? 'Edit Mode' : 'Add New Mode'}</h2>
             <form onSubmit={handleSubmit} className="space-y-3">

--- a/src/pages/Students.jsx
+++ b/src/pages/Students.jsx
@@ -193,7 +193,7 @@ setStudents(Array.isArray(res.data?.data) ? res.data.data : []);
 
       {/* Modal */}
       {showModal && (
-        <div className="fixed inset-0 bg-black bg-opacity-40 flex items-center justify-center z-50">
+        <div className="fixed inset-0 bg-black bg-opacity-40 flex items-center justify-center p-4 overflow-y-auto z-[60]">
           <div className="bg-white p-6 rounded-xl w-full max-w-md shadow-lg">
             <h2 className="text-xl font-semibold mb-4">{editingId ? 'Edit Student' : 'Add New Student'}</h2>
             <form onSubmit={handleSubmit} className="grid grid-cols-1 gap-4">

--- a/src/pages/User.jsx
+++ b/src/pages/User.jsx
@@ -228,7 +228,7 @@ const User = () => {
       )}
 
       {showModal && (
-        <div className="fixed inset-0 bg-black bg-opacity-40 flex items-center justify-center z-50">
+        <div className="fixed inset-0 bg-black bg-opacity-40 flex items-center justify-center p-4 overflow-y-auto z-[60]">
           <div className="bg-white p-6 rounded-xl w-full max-w-md shadow-lg">
             <h2 className="text-xl font-semibold mb-4">{editingId ? 'Edit User' : 'Add New User'}</h2>
             <form onSubmit={handleSubmit} className="space-y-3">

--- a/src/pages/addPayment.jsx
+++ b/src/pages/addPayment.jsx
@@ -200,7 +200,7 @@ export default function AddPayment() {
   }
 
   return (
-    <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-50 z-50">
+    <div className="fixed inset-0 flex items-center justify-center p-4 overflow-y-auto bg-black bg-opacity-50 z-[60]">
       <Toaster />
       <div className="bg-white rounded shadow-lg p-6 w-full max-w-lg relative">
         {/* X Close Button */}
@@ -302,7 +302,7 @@ export default function AddPayment() {
 
       {/* WhatsApp Confirmation Modal */}
       {showWhatsAppModal && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-40">
+        <div className="fixed inset-0 z-[60] flex items-center justify-center p-4 overflow-y-auto bg-black bg-opacity-40">
           <div className="bg-white rounded-2xl shadow-xl p-6 w-full max-w-sm relative animate-fadeIn">
             <button
               className="absolute top-2 right-2 text-gray-500 hover:text-red-600 text-xl p-2 rounded-full focus:outline-none"

--- a/src/pages/addReciept.jsx
+++ b/src/pages/addReciept.jsx
@@ -199,7 +199,7 @@ export default function AddReceipt() {
     };
 
     return (
-        <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-50 z-50">
+        <div className="fixed inset-0 flex items-center justify-center p-4 overflow-y-auto bg-black bg-opacity-50 z-[60]">
             <Toaster />
             <div className="bg-white rounded shadow-lg p-6 w-full max-w-lg relative">
                 {/* X close button */}
@@ -300,7 +300,7 @@ export default function AddReceipt() {
             </div>
             {/* WhatsApp Confirmation Modal (unchanged) */}
             {showWhatsAppModal && (
-                <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-40">
+                <div className="fixed inset-0 z-[60] flex items-center justify-center p-4 overflow-y-auto bg-black bg-opacity-40">
                     <div className="bg-white rounded-2xl shadow-xl p-6 w-full max-w-sm relative animate-fadeIn">
                         <button
                             className="absolute top-2 right-2 text-gray-500 hover:text-red-600 text-xl p-2 rounded-full focus:outline-none"

--- a/src/reports/allAdmission.jsx
+++ b/src/reports/allAdmission.jsx
@@ -74,7 +74,7 @@ const AllAdmission = () => {
       <Toaster />
 
       {selectedAdmission && (
-        <div className="fixed inset-0 bg-black bg-opacity-40 flex items-center justify-center z-50">
+        <div className="fixed inset-0 bg-black bg-opacity-40 flex items-center justify-center p-4 overflow-y-auto z-[60]">
           <div className="bg-white p-6 rounded shadow max-w-md w-full">
             <h2 className="text-lg font-bold mb-4">
               {selectedAdmission.student?.firstName} {selectedAdmission.student?.lastName}


### PR DESCRIPTION
## Summary
- avoid overlap with fixed navbar and footer by adding extra padding to the main content
- raise z-index for all modals and make them scrollable
- allow modal bodies to occupy full screen height

## Testing
- `npm run build` *(fails: 403 Forbidden fetching vite)*

------
https://chatgpt.com/codex/tasks/task_e_6873be6d19848322b968fefc0880d5c8