### PR TITLE
Add WhatsApp Cloud integration module (center settings + lead messaging)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,4 @@
 VITE_BASE_URL=http://localhost:5000
 VITE_DB_SECRET_KEY=jpzWRwvG!AH}}ucp^)UsaFsTkMPT]psHfp:Vdd2wKYo2Jrqzayc3?_5zagmjy!m!me1e7@>2
+VITE_META_APP_ID=
+VITE_META_WHATSAPP_CONFIG_ID=

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -39,6 +39,7 @@ import Students from './pages/Students';
 import Fees from './pages/Fees';
 import ToolsPanel from './pages/ToolsPanel';
 import AllTransaction3 from './reports/allTransaction3';
+import WhatsAppIntegrationSettingsPage from './modules/whatsapp/pages/WhatsAppIntegrationSettingsPage';
 
 export default function App() {
   return (
@@ -81,6 +82,7 @@ export default function App() {
         <Route path="allBalance" element={<AllBalance />} /> {/* ✅ Added Route */}
         <Route path="allBatches" element={<AllBatches />} /> {/* ✅ Added Route */}
         <Route path="whatsapp" element={<WhatsAppAdminPage />} />
+        <Route path="dashboard/centers/:centerId/whatsapp" element={<WhatsAppIntegrationSettingsPage />} />
         <Route path="allExams" element={<AllExams />} />
         <Route path="fees" element={<Fees />} />
         <Route path="tools" element={<ToolsPanel />} />

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -150,7 +150,7 @@ useEffect(() => {
       group: "Profile",
       icon: FiDollarSign,
       items: [
-        { label: "Institute Profile", path: `/${currentUsername}/instituteProfile` },
+        { label: "Institute Profile", path: "/dashboard/instituteProfile" },
       ],
     },
     {

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -34,6 +34,7 @@ const Navbar = () => {
 
   const navigate = useNavigate();
   const location = useLocation();
+  const currentUsername = location.pathname.split('/').filter(Boolean)[0] || 'admin';
   const dropdownRef = useRef();
 
 const username = user?.name || 'User';
@@ -149,8 +150,14 @@ useEffect(() => {
       group: "Profile",
       icon: FiDollarSign,
       items: [
-        { label: "Institute Profile", path: "/dashboard/instituteProfile" },
-        
+        { label: "Institute Profile", path: `/${currentUsername}/instituteProfile` },
+      ],
+    },
+    {
+      group: "Integrations",
+      icon: FiRepeat,
+      items: [
+        { label: "WhatsApp Integration", path: `/${currentUsername}/dashboard/centers/${localStorage.getItem('institute_uuid') || ''}/whatsapp` },
       ],
     },
    

--- a/src/components/leads/LeadStatusModal.jsx
+++ b/src/components/leads/LeadStatusModal.jsx
@@ -4,6 +4,7 @@ import toast from 'react-hot-toast';
 import BASE_URL from '../../config';
 import { useNavigate } from 'react-router-dom';
 import LeadEditModal from './LeadEditModal';
+import SendWhatsAppMessageModal from '../../modules/whatsapp/components/SendWhatsAppMessageModal';
 
 const LeadStatusModal = ({ lead, onClose, refresh }) => {
   const [status, setStatus] = useState(lead.leadStatus || '');
@@ -11,6 +12,7 @@ const LeadStatusModal = ({ lead, onClose, refresh }) => {
   const [followUpDate, setFollowUpDate] = useState(new Date().toISOString().substring(0, 10));
   const [loading, setLoading] = useState(false);
   const [showEditModal, setShowEditModal] = useState(false);
+  const [showWhatsAppModal, setShowWhatsAppModal] = useState(false);
   const [courses, setCourses] = useState([]);
   const navigate = useNavigate();
 
@@ -113,12 +115,18 @@ const LeadStatusModal = ({ lead, onClose, refresh }) => {
             </button>
           </div>
         )}
-        <div className="flex justify-end gap-2">
+        <div className="flex justify-end gap-2 flex-wrap">
           <button
             onClick={onClose}
             className="px-4 py-2 bg-gray-300 rounded hover:bg-gray-400"
           >
             Cancel
+          </button>
+          <button
+            onClick={() => setShowWhatsAppModal(true)}
+            className="px-4 py-2 bg-green-600 text-white rounded hover:bg-green-700"
+          >
+            Send WhatsApp Message
           </button>
           <button
             onClick={() => setShowEditModal(true)}
@@ -135,6 +143,14 @@ const LeadStatusModal = ({ lead, onClose, refresh }) => {
           </button>
         </div>
       </div>
+      {showWhatsAppModal && (
+        <SendWhatsAppMessageModal
+          isOpen={showWhatsAppModal}
+          centerId={localStorage.getItem('institute_uuid')}
+          contact={lead?.studentData?.mobileSelf || lead?.student?.mobileSelf || ''}
+          onClose={() => setShowWhatsAppModal(false)}
+        />
+      )}
       {showEditModal && (
         <LeadEditModal
           lead={lead}

--- a/src/modules/whatsapp/components/ConnectWhatsAppModal.jsx
+++ b/src/modules/whatsapp/components/ConnectWhatsAppModal.jsx
@@ -3,6 +3,12 @@ import toast from 'react-hot-toast';
 import { connectEmbedded, connectManual } from '../services/whatsapp.api';
 
 const FB_SDK_ID = 'facebook-jssdk';
+const FB_VERSION = 'v21.0';
+const META_SCOPES = [
+  'business_management',
+  'whatsapp_business_management',
+  'whatsapp_business_messaging',
+].join(',');
 
 const loadFacebookSdk = () => {
   if (window.FB) return Promise.resolve(window.FB);
@@ -23,6 +29,48 @@ const loadFacebookSdk = () => {
     script.onload = () => resolve(window.FB);
     script.onerror = () => reject(new Error('Failed to load Facebook SDK'));
     document.body.appendChild(script);
+  });
+};
+
+const normalizeApiErrors = (err) => {
+  const responseData = err?.response?.data;
+  if (Array.isArray(responseData?.errors)) return responseData.errors.join('\n');
+  if (responseData?.errors && typeof responseData.errors === 'object') {
+    return Object.values(responseData.errors).flat().join('\n');
+  }
+  return responseData?.message || err?.message || 'Request failed.';
+};
+
+const requestEmbeddedSignupCode = async () => {
+  const FB = await loadFacebookSdk();
+  if (!FB) {
+    throw new Error('Facebook SDK not available.');
+  }
+
+  const appId = import.meta.env.VITE_META_APP_ID;
+  const configId = import.meta.env.VITE_META_WHATSAPP_CONFIG_ID;
+  if (!appId) {
+    throw new Error('VITE_META_APP_ID is missing.');
+  }
+
+  FB.init({ appId, cookie: true, xfbml: false, version: FB_VERSION });
+
+  return new Promise((resolve, reject) => {
+    FB.login(
+      (response) => {
+        if (response?.authResponse?.code) {
+          resolve(response.authResponse.code);
+          return;
+        }
+        reject(new Error('Meta authorization was cancelled or no auth code was returned.'));
+      },
+      {
+        scope: META_SCOPES,
+        response_type: 'code',
+        override_default_response_type: true,
+        ...(configId ? { config_id: configId } : {}),
+      },
+    );
   });
 };
 
@@ -47,18 +95,13 @@ const ConnectWhatsAppModal = ({ isOpen, centerId, onClose, onConnected }) => {
     setSubmitting(true);
     setErrors('');
     try {
-      await loadFacebookSdk();
-      const code = window.prompt('Paste Meta Embedded Signup authorization code');
-      if (!code) {
-        setSubmitting(false);
-        return;
-      }
+      const code = await requestEmbeddedSignupCode();
       await connectEmbedded({ code, centerId });
       toast.success('WhatsApp connected with Meta Embedded Signup.');
       onConnected();
       onClose();
     } catch (err) {
-      setErrors(err?.response?.data?.message || 'Embedded signup failed.');
+      setErrors(normalizeApiErrors(err));
     } finally {
       setSubmitting(false);
     }
@@ -71,15 +114,11 @@ const ConnectWhatsAppModal = ({ isOpen, centerId, onClose, onConnected }) => {
     try {
       await connectManual({ centerId, ...manual });
       toast.success('Manual WhatsApp connection successful.');
+      setManual({ accessToken: '', phoneNumberId: '', wabaId: '', displayName: '' });
       onConnected();
       onClose();
     } catch (err) {
-      const backendErrors = err?.response?.data?.errors;
-      if (Array.isArray(backendErrors) && backendErrors.length) {
-        setErrors(backendErrors.join('\n'));
-      } else {
-        setErrors(err?.response?.data?.message || 'Manual connect failed.');
-      }
+      setErrors(normalizeApiErrors(err));
     } finally {
       setSubmitting(false);
     }

--- a/src/modules/whatsapp/components/ConnectWhatsAppModal.jsx
+++ b/src/modules/whatsapp/components/ConnectWhatsAppModal.jsx
@@ -1,0 +1,139 @@
+import { useState } from 'react';
+import toast from 'react-hot-toast';
+import { connectEmbedded, connectManual } from '../services/whatsapp.api';
+
+const FB_SDK_ID = 'facebook-jssdk';
+
+const loadFacebookSdk = () => {
+  if (window.FB) return Promise.resolve(window.FB);
+
+  return new Promise((resolve, reject) => {
+    const existing = document.getElementById(FB_SDK_ID);
+    if (existing) {
+      existing.addEventListener('load', () => resolve(window.FB));
+      existing.addEventListener('error', () => reject(new Error('Failed to load Facebook SDK')));
+      return;
+    }
+
+    const script = document.createElement('script');
+    script.id = FB_SDK_ID;
+    script.src = 'https://connect.facebook.net/en_US/sdk.js';
+    script.async = true;
+    script.defer = true;
+    script.onload = () => resolve(window.FB);
+    script.onerror = () => reject(new Error('Failed to load Facebook SDK'));
+    document.body.appendChild(script);
+  });
+};
+
+const ConnectWhatsAppModal = ({ isOpen, centerId, onClose, onConnected }) => {
+  const [activeTab, setActiveTab] = useState('embedded');
+  const [submitting, setSubmitting] = useState(false);
+  const [errors, setErrors] = useState('');
+  const [manual, setManual] = useState({
+    accessToken: '',
+    phoneNumberId: '',
+    wabaId: '',
+    displayName: '',
+  });
+
+  if (!isOpen) return null;
+
+  const onManualChange = (field, value) => {
+    setManual((prev) => ({ ...prev, [field]: value }));
+  };
+
+  const handleEmbeddedConnect = async () => {
+    setSubmitting(true);
+    setErrors('');
+    try {
+      await loadFacebookSdk();
+      const code = window.prompt('Paste Meta Embedded Signup authorization code');
+      if (!code) {
+        setSubmitting(false);
+        return;
+      }
+      await connectEmbedded({ code, centerId });
+      toast.success('WhatsApp connected with Meta Embedded Signup.');
+      onConnected();
+      onClose();
+    } catch (err) {
+      setErrors(err?.response?.data?.message || 'Embedded signup failed.');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const handleManualSubmit = async (e) => {
+    e.preventDefault();
+    setSubmitting(true);
+    setErrors('');
+    try {
+      await connectManual({ centerId, ...manual });
+      toast.success('Manual WhatsApp connection successful.');
+      onConnected();
+      onClose();
+    } catch (err) {
+      const backendErrors = err?.response?.data?.errors;
+      if (Array.isArray(backendErrors) && backendErrors.length) {
+        setErrors(backendErrors.join('\n'));
+      } else {
+        setErrors(err?.response?.data?.message || 'Manual connect failed.');
+      }
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-[70] bg-black/40 flex items-center justify-center p-4">
+      <div className="bg-white rounded-lg shadow-lg max-w-xl w-full">
+        <div className="border-b px-5 py-3 flex items-center justify-between">
+          <h3 className="font-semibold text-lg">Connect WhatsApp</h3>
+          <button onClick={onClose} className="text-gray-500">✕</button>
+        </div>
+
+        <div className="flex border-b text-sm">
+          <button className={`px-4 py-2 ${activeTab === 'embedded' ? 'border-b-2 border-blue-600 text-blue-600' : 'text-gray-600'}`} onClick={() => setActiveTab('embedded')}>
+            Connect via Meta
+          </button>
+          <button className={`px-4 py-2 ${activeTab === 'manual' ? 'border-b-2 border-blue-600 text-blue-600' : 'text-gray-600'}`} onClick={() => setActiveTab('manual')}>
+            Manual Connect
+          </button>
+        </div>
+
+        <div className="p-5">
+          {activeTab === 'embedded' && (
+            <div className="space-y-4">
+              <p className="text-sm text-gray-600">Use Meta Embedded Signup to securely authorize this center.</p>
+              <button
+                type="button"
+                onClick={handleEmbeddedConnect}
+                disabled={submitting}
+                className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700"
+              >
+                {submitting ? 'Connecting...' : 'Connect with Facebook'}
+              </button>
+            </div>
+          )}
+
+          {activeTab === 'manual' && (
+            <form className="space-y-3" onSubmit={handleManualSubmit}>
+              <input className="w-full border rounded p-2" placeholder="Access Token *" value={manual.accessToken} onChange={(e) => onManualChange('accessToken', e.target.value)} required />
+              <input className="w-full border rounded p-2" placeholder="Phone Number ID *" value={manual.phoneNumberId} onChange={(e) => onManualChange('phoneNumberId', e.target.value)} required />
+              <input className="w-full border rounded p-2" placeholder="WABA ID *" value={manual.wabaId} onChange={(e) => onManualChange('wabaId', e.target.value)} required />
+              <input className="w-full border rounded p-2" placeholder="Display Name (Optional)" value={manual.displayName} onChange={(e) => onManualChange('displayName', e.target.value)} />
+              <button type="submit" disabled={submitting} className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700">
+                {submitting ? 'Saving...' : 'Connect'}
+              </button>
+            </form>
+          )}
+
+          {errors && <div className="mt-4 whitespace-pre-line text-sm text-red-600 bg-red-50 p-3 rounded">{errors}</div>}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ConnectWhatsAppModal;

--- a/src/modules/whatsapp/components/SendWhatsAppMessageModal.jsx
+++ b/src/modules/whatsapp/components/SendWhatsAppMessageModal.jsx
@@ -1,0 +1,141 @@
+import { useEffect, useMemo, useState } from 'react';
+import toast from 'react-hot-toast';
+import { getConnectedNumbers, getTemplates, sendTextMessage } from '../services/whatsapp.api';
+
+const SendWhatsAppMessageModal = ({ isOpen, centerId, contact, onClose }) => {
+  const [loading, setLoading] = useState(false);
+  const [numbers, setNumbers] = useState([]);
+  const [templates, setTemplates] = useState([]);
+  const [form, setForm] = useState({
+    integrationId: '',
+    mode: 'text',
+    message: '',
+    templateName: '',
+    to: contact || '',
+  });
+  const [result, setResult] = useState(null);
+
+  useEffect(() => {
+    setForm((prev) => ({ ...prev, to: contact || '' }));
+  }, [contact]);
+
+  useEffect(() => {
+    if (!isOpen || !centerId) return;
+    const load = async () => {
+      try {
+        const numberRes = await getConnectedNumbers(centerId);
+        const rows = numberRes?.data || numberRes?.numbers || numberRes || [];
+        const list = Array.isArray(rows) ? rows : [];
+        setNumbers(list);
+        if (list[0] && !form.integrationId) {
+          setForm((prev) => ({ ...prev, integrationId: list[0].id || list[0].integrationId || '' }));
+        }
+      } catch (err) {
+        toast.error(err?.response?.data?.message || 'Unable to load connected numbers.');
+      }
+    };
+    load();
+  }, [isOpen, centerId]);
+
+  const selectedIntegration = useMemo(() => numbers.find((n) => (n.id || n.integrationId) === form.integrationId), [numbers, form.integrationId]);
+
+  useEffect(() => {
+    if (!isOpen || !form.integrationId || form.mode !== 'template') return;
+    const loadTemplates = async () => {
+      try {
+        const response = await getTemplates(centerId, form.integrationId);
+        const rows = response?.data || response?.templates || response || [];
+        setTemplates(Array.isArray(rows) ? rows : []);
+      } catch (err) {
+        toast.error(err?.response?.data?.message || 'Unable to load templates.');
+      }
+    };
+    loadTemplates();
+  }, [isOpen, centerId, form.integrationId, form.mode]);
+
+  if (!isOpen) return null;
+
+  const handleSend = async () => {
+    if (!form.integrationId || !form.to) {
+      toast.error('Connected number and recipient are required.');
+      return;
+    }
+
+    setLoading(true);
+    setResult(null);
+    try {
+      const payload = {
+        centerId,
+        institute_uuid: centerId,
+        integrationId: form.integrationId,
+        to: form.to,
+        type: form.mode,
+        message: form.mode === 'text' ? form.message : undefined,
+        templateName: form.mode === 'template' ? form.templateName : undefined,
+      };
+      const response = await sendTextMessage(payload);
+      setResult(response?.data || response);
+      toast.success('WhatsApp message sent.');
+    } catch (err) {
+      toast.error(err?.response?.data?.message || 'Failed to send WhatsApp message.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-[70] bg-black/40 flex items-center justify-center p-4">
+      <div className="bg-white w-full max-w-lg rounded-lg shadow-lg">
+        <div className="px-4 py-3 border-b flex justify-between items-center">
+          <h3 className="font-semibold">Send WhatsApp Message</h3>
+          <button onClick={onClose}>✕</button>
+        </div>
+
+        <div className="p-4 space-y-3">
+          <select className="w-full border rounded p-2" value={form.integrationId} onChange={(e) => setForm((p) => ({ ...p, integrationId: e.target.value }))}>
+            <option value="">Select Connected Number</option>
+            {numbers.map((n) => (
+              <option key={n.id || n.integrationId} value={n.id || n.integrationId}>
+                {(n.displayName || n.phoneNumber || n.phone_number) + ` (${n.wabaId || n.waba_id || 'WABA'})`}
+              </option>
+            ))}
+          </select>
+
+          <input className="w-full border rounded p-2" value={form.to} onChange={(e) => setForm((p) => ({ ...p, to: e.target.value }))} placeholder="Recipient phone" />
+
+          <div className="flex gap-3 text-sm">
+            <label><input type="radio" checked={form.mode === 'text'} onChange={() => setForm((p) => ({ ...p, mode: 'text' }))} /> Text</label>
+            <label><input type="radio" checked={form.mode === 'template'} onChange={() => setForm((p) => ({ ...p, mode: 'template' }))} /> Template</label>
+          </div>
+
+          {form.mode === 'text' ? (
+            <textarea className="w-full border rounded p-2" rows={4} placeholder="Type message" value={form.message} onChange={(e) => setForm((p) => ({ ...p, message: e.target.value }))} />
+          ) : (
+            <select className="w-full border rounded p-2" value={form.templateName} onChange={(e) => setForm((p) => ({ ...p, templateName: e.target.value }))}>
+              <option value="">Select Template</option>
+              {templates.map((t) => (
+                <option key={t.id || t.name} value={t.name}>{t.name}</option>
+              ))}
+            </select>
+          )}
+
+          <button onClick={handleSend} disabled={loading} className="bg-green-600 text-white px-4 py-2 rounded hover:bg-green-700">
+            {loading ? 'Sending...' : 'Send WhatsApp Message'}
+          </button>
+
+          {selectedIntegration && (
+            <div className="text-xs text-gray-500">Using: {selectedIntegration.phoneNumber || selectedIntegration.phone_number || selectedIntegration.displayName}</div>
+          )}
+
+          {result && (
+            <div className="bg-green-50 text-green-700 text-sm p-2 rounded">
+              Status: {result.status || result.messageStatus || 'sent'}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default SendWhatsAppMessageModal;

--- a/src/modules/whatsapp/components/SendWhatsAppMessageModal.jsx
+++ b/src/modules/whatsapp/components/SendWhatsAppMessageModal.jsx
@@ -35,7 +35,7 @@ const SendWhatsAppMessageModal = ({ isOpen, centerId, contact, onClose }) => {
       }
     };
     load();
-  }, [isOpen, centerId]);
+  }, [isOpen, centerId, form.integrationId]);
 
   const selectedIntegration = useMemo(() => numbers.find((n) => (n.id || n.integrationId) === form.integrationId), [numbers, form.integrationId]);
 

--- a/src/modules/whatsapp/hooks/useWhatsAppIntegrations.js
+++ b/src/modules/whatsapp/hooks/useWhatsAppIntegrations.js
@@ -1,0 +1,31 @@
+import { useCallback, useEffect, useState } from 'react';
+import { getIntegrations } from '../services/whatsapp.api';
+
+export const useWhatsAppIntegrations = (centerId) => {
+  const [integrations, setIntegrations] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+
+  const fetchIntegrations = useCallback(async () => {
+    if (!centerId) return;
+    setLoading(true);
+    setError('');
+    try {
+      const response = await getIntegrations(centerId);
+      const rows = response?.data || response?.integrations || response || [];
+      setIntegrations(Array.isArray(rows) ? rows : []);
+    } catch (err) {
+      setError(err?.response?.data?.message || 'Failed to load WhatsApp integrations.');
+    } finally {
+      setLoading(false);
+    }
+  }, [centerId]);
+
+  useEffect(() => {
+    fetchIntegrations();
+  }, [fetchIntegrations]);
+
+  return { integrations, loading, error, refetch: fetchIntegrations };
+};
+
+export default useWhatsAppIntegrations;

--- a/src/modules/whatsapp/pages/WhatsAppIntegrationSettingsPage.jsx
+++ b/src/modules/whatsapp/pages/WhatsAppIntegrationSettingsPage.jsx
@@ -1,0 +1,113 @@
+import { useMemo, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import toast from 'react-hot-toast';
+import useWhatsAppIntegrations from '../hooks/useWhatsAppIntegrations';
+import ConnectWhatsAppModal from '../components/ConnectWhatsAppModal';
+import { disconnectIntegration, syncTemplates } from '../services/whatsapp.api';
+
+const StatusBadge = ({ connected }) => (
+  <span className={`px-2 py-1 text-xs rounded-full font-semibold ${connected ? 'bg-green-100 text-green-700' : 'bg-gray-100 text-gray-600'}`}>
+    {connected ? 'Connected' : 'Not Connected'}
+  </span>
+);
+
+const WhatsAppIntegrationSettingsPage = () => {
+  const { centerId } = useParams();
+  const fallbackCenterId = localStorage.getItem('institute_uuid');
+  const activeCenterId = centerId || fallbackCenterId;
+  const [openConnectModal, setOpenConnectModal] = useState(false);
+  const [submittingId, setSubmittingId] = useState('');
+
+  const { integrations, loading, error, refetch } = useWhatsAppIntegrations(activeCenterId);
+
+  const activeIntegration = useMemo(() => integrations[0] || null, [integrations]);
+
+  const handleDisconnect = async (integrationId) => {
+    setSubmittingId(integrationId);
+    try {
+      await disconnectIntegration(activeCenterId, integrationId);
+      toast.success('WhatsApp disconnected.');
+      refetch();
+    } catch (err) {
+      toast.error(err?.response?.data?.message || 'Disconnect failed.');
+    } finally {
+      setSubmittingId('');
+    }
+  };
+
+  const handleSyncTemplates = async (integrationId) => {
+    setSubmittingId(integrationId);
+    try {
+      await syncTemplates(activeCenterId, integrationId);
+      toast.success('Templates synced.');
+    } catch (err) {
+      toast.error(err?.response?.data?.message || 'Template sync failed.');
+    } finally {
+      setSubmittingId('');
+    }
+  };
+
+  return (
+    <div className="max-w-4xl mx-auto space-y-4">
+      <div className="flex justify-between items-center">
+        <div>
+          <h1 className="text-2xl font-semibold">WhatsApp Integration</h1>
+          <p className="text-sm text-gray-500">Center ID: {activeCenterId || 'Not detected'}</p>
+        </div>
+        <button onClick={() => setOpenConnectModal(true)} className="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700">
+          Connect WhatsApp
+        </button>
+      </div>
+
+      {loading && <div className="p-4 bg-white border rounded">Loading integration status...</div>}
+      {error && <div className="p-4 bg-red-50 text-red-700 border border-red-100 rounded">{error}</div>}
+
+      {!loading && !activeIntegration && (
+        <div className="p-4 bg-white border rounded flex justify-between items-center">
+          <div>
+            <h2 className="font-medium">No active WhatsApp integration</h2>
+            <p className="text-sm text-gray-500">Connect a WhatsApp Cloud account for this center.</p>
+          </div>
+          <StatusBadge connected={false} />
+        </div>
+      )}
+
+      {activeIntegration && (
+        <div className="p-5 bg-white border rounded-lg shadow-sm space-y-4">
+          <div className="flex justify-between">
+            <h2 className="text-lg font-semibold">Current Connection</h2>
+            <StatusBadge connected={Boolean(activeIntegration.connected ?? true)} />
+          </div>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-3 text-sm">
+            <div className="border rounded p-3">
+              <div className="text-gray-500">Phone Number</div>
+              <div className="font-medium">{activeIntegration.phoneNumber || activeIntegration.phone_number || '—'}</div>
+            </div>
+            <div className="border rounded p-3">
+              <div className="text-gray-500">WABA ID</div>
+              <div className="font-medium">{activeIntegration.wabaId || activeIntegration.waba_id || '—'}</div>
+            </div>
+          </div>
+
+          <div className="flex flex-wrap gap-2">
+            <button onClick={() => handleSyncTemplates(activeIntegration.id || activeIntegration.integrationId)} disabled={Boolean(submittingId)} className="px-4 py-2 bg-indigo-600 text-white rounded hover:bg-indigo-700">
+              Sync Templates
+            </button>
+            <button onClick={() => handleDisconnect(activeIntegration.id || activeIntegration.integrationId)} disabled={Boolean(submittingId)} className="px-4 py-2 bg-red-600 text-white rounded hover:bg-red-700">
+              Disconnect
+            </button>
+          </div>
+        </div>
+      )}
+
+      <ConnectWhatsAppModal
+        isOpen={openConnectModal}
+        centerId={activeCenterId}
+        onClose={() => setOpenConnectModal(false)}
+        onConnected={refetch}
+      />
+    </div>
+  );
+};
+
+export default WhatsAppIntegrationSettingsPage;

--- a/src/modules/whatsapp/services/whatsapp.api.js
+++ b/src/modules/whatsapp/services/whatsapp.api.js
@@ -1,0 +1,81 @@
+import axios from 'axios';
+import BASE_URL from '../../../config';
+
+const authHeaders = () => {
+  const token = localStorage.getItem('authToken') || localStorage.getItem('token');
+  return token ? { Authorization: `Bearer ${token}` } : {};
+};
+
+const withCenter = (data, centerId) => ({
+  ...data,
+  centerId,
+  institute_uuid: centerId,
+});
+
+export const getIntegrations = async (centerId) => {
+  const { data } = await axios.get(`${BASE_URL}/api/whatsapp/integrations`, {
+    params: { centerId, institute_uuid: centerId },
+    headers: authHeaders(),
+  });
+  return data;
+};
+
+export const connectManual = async (payload) => {
+  const { centerId, ...credentials } = payload;
+  const { data } = await axios.post(
+    `${BASE_URL}/api/whatsapp/manual/connect`,
+    withCenter(credentials, centerId),
+    { headers: authHeaders() },
+  );
+  return data;
+};
+
+export const connectEmbedded = async ({ code, centerId }) => {
+  const { data } = await axios.post(
+    `${BASE_URL}/api/whatsapp/embedded/exchange`,
+    withCenter({ code }, centerId),
+    { headers: authHeaders() },
+  );
+  return data;
+};
+
+export const disconnectIntegration = async (centerId, integrationId) => {
+  const { data } = await axios.post(
+    `${BASE_URL}/api/whatsapp/disconnect`,
+    withCenter({ integrationId }, centerId),
+    { headers: authHeaders() },
+  );
+  return data;
+};
+
+export const syncTemplates = async (centerId, integrationId) => {
+  const { data } = await axios.post(
+    `${BASE_URL}/api/whatsapp/templates/sync`,
+    withCenter({ integrationId }, centerId),
+    { headers: authHeaders() },
+  );
+  return data;
+};
+
+export const getTemplates = async (centerId, integrationId) => {
+  const { data } = await axios.get(`${BASE_URL}/api/whatsapp/templates`, {
+    params: { centerId, institute_uuid: centerId, integrationId },
+    headers: authHeaders(),
+  });
+  return data;
+};
+
+export const getConnectedNumbers = async (centerId) => {
+  const { data } = await axios.get(`${BASE_URL}/api/whatsapp/numbers`, {
+    params: { centerId, institute_uuid: centerId },
+    headers: authHeaders(),
+  });
+  return data;
+};
+
+export const sendTextMessage = async (payload) => {
+  const { data } = await axios.post(`${BASE_URL}/api/whatsapp/messages/send`, payload, {
+    headers: authHeaders(),
+  });
+  return data;
+};


### PR DESCRIPTION
### Motivation
- Provide a non-destructive, center-scoped WhatsApp Cloud integration so each Center can connect a WABA and manage templates within the existing CRM architecture. 
- Support both Meta Embedded Signup and manual credential flows to match BSP-style onboarding requirements. 
- Enable CRM users to send WhatsApp messages from contact/lead screens using connected center numbers without changing global auth/state systems.

### Description
- Added an additive feature module at `src/modules/whatsapp/` with `services/`, `hooks/`, `components/`, and `pages/` including `whatsapp.api.js`, `useWhatsAppIntegrations.js`, `ConnectWhatsAppModal.jsx`, `SendWhatsAppMessageModal.jsx`, and `WhatsAppIntegrationSettingsPage.jsx` to implement the requested flows. 
- Implemented API helpers using the existing Axios setup and auth headers: `getIntegrations`, `connectManual`, `connectEmbedded`, `disconnectIntegration`, `syncTemplates`, `getTemplates`, `getConnectedNumbers`, and `sendTextMessage` in `src/modules/whatsapp/services/whatsapp.api.js`. 
- Added `useWhatsAppIntegrations(centerId)` hook for loading/refetching integration state and a center-level settings page at route `/:username/dashboard/centers/:centerId/whatsapp` plus a tabbed Connect modal (Meta Embedded + Manual) that surfaces backend validation errors. 
- Integrated send-flow into the lead modal with a `Send WhatsApp Message` button and modal that selects a connected number, supports text/template messages, auto-fills recipient from lead data, and shows message status; added a navbar menu entry linking to the center settings route and the new route in `src/App.jsx`.

### Testing
- Built the app with `npm run build` and the production build completed successfully (bundle warnings only). 
- Started the dev server and executed an automated Playwright smoke script that loaded `http://localhost:4173/admin/dashboard/centers/center-001/whatsapp` and captured a screenshot of the integration settings page, which completed successfully.
- No unit tests were added or modified as part of this change; functionality was smoke-tested via the build and the Playwright UI check.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69982acee0688322a0c7001d6447a8d6)